### PR TITLE
Update ApolloClient__Graphql_Language.res so type documentNode is no longer abstract.

### DIFF
--- a/src/graphql/language/ApolloClient__Graphql_Language.res
+++ b/src/graphql/language/ApolloClient__Graphql_Language.res
@@ -1,3 +1,3 @@
 module Ast = ApolloClient__Graphql_Language_Ast
 
-type documentNode
+type documentNode = string


### PR DESCRIPTION
I just started a new project with the latest version of rescript and rescript-apollo client on the backend nodejs. And ran into the following error:
![image](https://user-images.githubusercontent.com/6032276/121466614-003b8c00-c9b8-11eb-84e6-1fd6efccdeb1.png)

Making that change solved it for me. But I don't know the nuances of this change at all...

(additional info, I tried this code on bs-platform 9.0.2 also, same thing error)