### PR TITLE
fix: uncurried invoke

### DIFF
--- a/src/@apollo/client/link/error/ApolloClient__Link_Error.res
+++ b/src/@apollo/client/link/error/ApolloClient__Link_Error.res
@@ -65,7 +65,9 @@ module ErrorResponse = {
       operation: Operation.Js_.t,
     }
 
-    @bs.send external forward: t => NextLink.Js_.t = "forward"
+    @send
+    external forward: (t, Operation.t) => Observable.Js_.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t> =
+      "forward"
   }
 
   type t_networkError =
@@ -92,7 +94,7 @@ module ErrorResponse = {
     ),
     response: js.response,
     operation: js.operation->Operation.fromJs,
-    forward: operation => js->Js_.forward(operation->Operation.toJs),
+    forward: operation => js->Js_.forward(operation),
   }
 }
 


### PR DESCRIPTION
https://github.com/jeddeloh/rescript-apollo-client/issues/116

Fixed an issue where objects could not be found due to unnecessary currying.

You can now properly use the forward function in ErrorLink 

### Now It Works

```res
let errorLink: ApolloClient.Link.t = ApolloClient.Link.ErrorLink.make(handler => {
  // Todo forward, operation 처리
  let {networkError, graphQLErrors, operation, response, forward} = handler

  switch graphQLErrors {
  | Some(e') => e'->Array.map(v => v->handleGraphQLError)
  | None => [()]
  }->ignore

  switch networkError {
  | Some(networkError') => handleNetworkError(networkError')
  | None => ()
  }->ignore

  switch response {
  | Some(response') => Js.log2("Error Link response", response')
  | None => ()
  }->ignore

  let dict = Js.Dict.empty()
  let headers = Js.Dict.empty()
  headers->Js.Dict.set(
    "Authorization",
    "Bearer XXX",
  )
  dict->Js.Dict.set("headers", Obj.magic(headers)->Js.Json.object_)
  Js.log(dict)
  operation.setContext(Obj.magic(Obj.magic(dict)->Js.Json.object_))->ignore
  let link = forward(operation)
  Some(link)
})
```



### Before
```js

function fromJs(js) {
  return {
          graphQLErrors: js.graphQLErrors,
          networkError: Belt_Option.map(js.networkError, (function (networkError) {
                  var error = classify(networkError);
                  switch (error.TAG | 0) {
                    case /* Error */0 :
                        return {
                                TAG: /* FetchFailure */0,
                                _0: error._0
                              };
                    case /* ServerError */1 :
                        var error$1 = error._0;
                        return {
                                TAG: /* BadStatus */1,
                                _0: error$1.statusCode,
                                _1: error$1
                              };
                    case /* ServerParseError */2 :
                        return {
                                TAG: /* BadBody */2,
                                _0: error._0
                              };
                    
                  }
                })),
          response: js.response,
          operation: ApolloClient__Link_Core_Types.Operation.fromJs(js.operation),
          forward: (function (operation) {
              return Curry._1(js.forward(), operation);
            })
        };
}
```

### After
```js

function fromJs(js) {
  return {
          graphQLErrors: js.graphQLErrors,
          networkError: Belt_Option.map(js.networkError, (function (networkError) {
                  var error = classify(networkError);
                  switch (error.TAG | 0) {
                    case /* Error */0 :
                        return {
                                TAG: /* FetchFailure */0,
                                _0: error._0
                              };
                    case /* ServerError */1 :
                        var error$1 = error._0;
                        return {
                                TAG: /* BadStatus */1,
                                _0: error$1.statusCode,
                                _1: error$1
                              };
                    case /* ServerParseError */2 :
                        return {
                                TAG: /* BadBody */2,
                                _0: error._0
                              };
                    
                  }
                })),
          response: js.response,
          operation: ApolloClient__Link_Core_Types.Operation.fromJs(js.operation),
          forward: (function (operation) {
              return js.forward(operation);
            })
        };
}
```
