### PR TITLE
Bind mocked provider

### DIFF
--- a/src/@apollo/client/ApolloClient__Client.res
+++ b/src/@apollo/client/ApolloClient__Client.res
@@ -66,3 +66,4 @@ module Errors = ApolloClient__Errors
 module Link = ApolloClient__Link
 module React = ApolloClient__React
 module Utilities = ApolloClient__Utilities
+module Testing = ApolloClient__Testing

--- a/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
+++ b/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
@@ -305,7 +305,6 @@ module Js_ = {
   @send
   external clearStore: t => Js.Promise.t<array<Js.Json.t>> = "clearStore"
 
-
   // extract(optimistic?: boolean): TCacheShape;
   @send
   external extract: (t, ~optimistic: bool=?, unit) => Js.Json.t = "extract"
@@ -360,6 +359,9 @@ module Js_ = {
 
   // setLink(newLink: ApolloLink): void;
   @send external setLink: (t, ApolloLink.Js_.t) => unit = "setLink"
+
+  // stop(): void;
+  @send external stop: (t, unit) => unit = "stop"
 
   // subscribe<T = any, TVariables = OperationVariables>(options: SubscriptionOptions<TVariables>): Observable<FetchResult<T>>;
 
@@ -462,6 +464,7 @@ type t = {
   restore: (~serializedState: Js.Json.t) => ApolloCache.t<Js.Json.t>,
   @as("rescript_setLink")
   setLink: ApolloLink.t => unit,
+  stop: unit => unit,
   @as("rescript_subscribe")
   subscribe: 'data 'variables 'jsVariables. (
     ~subscription: module(Operation with
@@ -583,7 +586,7 @@ let make: (
     ->Js.Promise.then_(value => Js.Promise.resolve(Ok(value)), _)
     ->Js.Promise.catch(e => Js.Promise.resolve(Error(Utils.ensureError(Any(e)))), _)
 
-  let extract = (~optimistic=?, ()) => jsClient->Js_.extract(~optimistic=?optimistic, ())
+  let extract = (~optimistic=?, ()) => jsClient->Js_.extract(~optimistic?, ())
 
   let mutate = (
     type data variables jsVariables,
@@ -761,6 +764,8 @@ let make: (
 
   let setLink = link => jsClient->Js_.setLink(link)
 
+  let stop = () => jsClient->Js_.stop()
+
   let subscribe = (
     type data variables jsVariables,
     ~subscription as module(Operation: Operation with
@@ -907,6 +912,7 @@ let make: (
       resetStore: resetStore,
       restore: restore,
       setLink: setLink,
+      stop: stop,
       subscribe: subscribe,
       watchQuery: watchQuery,
       writeFragment: writeFragment,

--- a/src/@apollo/client/testing/ApolloClient__MockedProvider.res
+++ b/src/@apollo/client/testing/ApolloClient__MockedProvider.res
@@ -1,0 +1,7 @@
+@react.component @module("@apollo/client/testing")
+external make: (
+  ~mocks: array<mock<'jsVariables>>,
+  ~addTypeName: bool=?,
+  ~cache: InMemoryCache.t=?,
+  ~children: React.element,
+) => React.element = "MockedProvider"

--- a/src/@apollo/client/testing/ApolloClient__MockedProvider.res
+++ b/src/@apollo/client/testing/ApolloClient__MockedProvider.res
@@ -1,7 +1,0 @@
-@react.component @module("@apollo/client/testing")
-external make: (
-  ~mocks: array<mock<'jsVariables>>,
-  ~addTypeName: bool=?,
-  ~cache: InMemoryCache.t=?,
-  ~children: React.element,
-) => React.element = "MockedProvider"

--- a/src/@apollo/client/testing/ApolloClient__Testing.res
+++ b/src/@apollo/client/testing/ApolloClient__Testing.res
@@ -1,5 +1,6 @@
 module Graphql = ApolloClient__Graphql
 module ApolloError = ApolloClient__Errors_ApolloError
+module InMemoryCache = ApolloClient__Cache_InMemory_InMemoryCache
 
 type rec request<'jsVariables> = {
   query: Graphql.documentNode,
@@ -38,4 +39,12 @@ let makeResult = (
   mockResult(queryResult)
 }
 
-module MockedProvider = ApolloClient__MockedProvider
+module MockedProvider = {
+  @react.component @module("@apollo/client/testing")
+  external make: (
+    ~mocks: array<mock<'jsVariables>>,
+    ~addTypeName: bool=?,
+    ~cache: InMemoryCache.t=?,
+    ~children: React.element,
+  ) => React.element = "MockedProvider"
+}

--- a/src/@apollo/client/testing/ApolloClient__Testing.res
+++ b/src/@apollo/client/testing/ApolloClient__Testing.res
@@ -1,0 +1,41 @@
+module Graphql = ApolloClient__Graphql
+module ApolloError = ApolloClient__Errors_ApolloError
+
+type rec request<'jsVariables> = {
+  query: Graphql.documentNode,
+  variables: 'jsVariables,
+}
+
+type result
+
+type mock<'jsVariables> = {
+  request: request<'jsVariables>,
+  result: result,
+}
+
+type queryResult = {
+  data: Js.Nullable.t<Js.Json.t>,
+  error: Js.Nullable.t<ApolloError.t>,
+  loading: bool,
+}
+
+external mockResult: queryResult => result = "%identity"
+
+let makeResult = (
+  ~data: option<'jsData>=?,
+  ~error: option<ApolloError.t>=?,
+  ~loading=false,
+  toJson: 'jsData => Js.Json.t,
+): result => {
+  let queryResult = {
+    data: data->Belt.Option.mapWithDefault(Js.Nullable.null, data =>
+      data->toJson->Js.Nullable.return
+    ),
+    error: error->Belt.Option.mapWithDefault(Js.Nullable.null, Js.Nullable.return),
+    loading: loading,
+  }
+
+  mockResult(queryResult)
+}
+
+module MockedProvider = ApolloClient__MockedProvider

--- a/src/@apollo/client/testing/ApolloClient__Testing.res
+++ b/src/@apollo/client/testing/ApolloClient__Testing.res
@@ -1,50 +1,5 @@
-module Graphql = ApolloClient__Graphql
-module ApolloError = ApolloClient__Errors_ApolloError
-module InMemoryCache = ApolloClient__Cache_InMemory_InMemoryCache
+module Core = ApolloClient__Testing_Core
+module Types = ApolloClient__Testing_Types
+module MockedProvider = ApolloClient__Testing_React.MockedProvider
 
-type rec request<'jsVariables> = {
-  query: Graphql.documentNode,
-  variables: 'jsVariables,
-}
-
-type result
-
-type mock<'jsVariables> = {
-  request: request<'jsVariables>,
-  result: result,
-}
-
-type queryResult = {
-  data: Js.Nullable.t<Js.Json.t>,
-  error: Js.Nullable.t<ApolloError.t>,
-  loading: bool,
-}
-
-external mockResult: queryResult => result = "%identity"
-
-let makeResult = (
-  ~data: option<'jsData>=?,
-  ~error: option<ApolloError.t>=?,
-  ~loading=false,
-  toJson: 'jsData => Js.Json.t,
-): result => {
-  let queryResult = {
-    data: data->Belt.Option.mapWithDefault(Js.Nullable.null, data =>
-      data->toJson->Js.Nullable.return
-    ),
-    error: error->Belt.Option.mapWithDefault(Js.Nullable.null, Js.Nullable.return),
-    loading: loading,
-  }
-
-  mockResult(queryResult)
-}
-
-module MockedProvider = {
-  @react.component @module("@apollo/client/testing")
-  external make: (
-    ~mocks: array<mock<'jsVariables>>,
-    ~addTypeName: bool=?,
-    ~cache: InMemoryCache.t=?,
-    ~children: React.element,
-  ) => React.element = "MockedProvider"
-}
+let makeResult = Types.makeResult

--- a/src/@apollo/client/testing/ApolloClient__Testing_Types.res
+++ b/src/@apollo/client/testing/ApolloClient__Testing_Types.res
@@ -1,0 +1,39 @@
+module Graphql = ApolloClient__Graphql
+module ApolloError = ApolloClient__Errors_ApolloError
+
+type rec request<'jsVariables> = {
+  query: Graphql.documentNode,
+  variables: 'jsVariables,
+}
+
+type result
+
+type mock<'jsVariables> = {
+  request: request<'jsVariables>,
+  result: result,
+}
+
+type queryResult = {
+  data: Js.Nullable.t<Js.Json.t>,
+  error: Js.Nullable.t<ApolloError.t>,
+  loading: bool,
+}
+
+external mockResult: queryResult => result = "%identity"
+
+let makeResult = (
+  ~data: option<'jsData>=?,
+  ~error: option<ApolloError.t>=?,
+  ~loading=false,
+  toJson: 'jsData => Js.Json.t,
+): result => {
+  let queryResult = {
+    data: data->Belt.Option.mapWithDefault(Js.Nullable.null, data =>
+      data->toJson->Js.Nullable.return
+    ),
+    error: error->Belt.Option.mapWithDefault(Js.Nullable.null, Js.Nullable.return),
+    loading: loading,
+  }
+
+  mockResult(queryResult)
+}

--- a/src/@apollo/client/testing/core/ApolloClient__Testing_Core.res
+++ b/src/@apollo/client/testing/core/ApolloClient__Testing_Core.res
@@ -1,0 +1,6 @@
+module Link = ApolloClient__Link_Core_ApolloLink
+module Types = ApolloClient__Testing_Types
+
+@new @module("@apollo/client/testing")
+external mockLink: (~mocks: array<Types.mock<'jsVariables>>, ~addTypename: bool) => Link.t =
+  "MockLink"

--- a/src/@apollo/client/testing/react/ApolloClient__Testing_React.res
+++ b/src/@apollo/client/testing/react/ApolloClient__Testing_React.res
@@ -1,0 +1,1 @@
+module MockedProvider = ApolloClient__Testing_React_MockedProvider

--- a/src/@apollo/client/testing/react/ApolloClient__Testing_React_MockedProvider.res
+++ b/src/@apollo/client/testing/react/ApolloClient__Testing_React_MockedProvider.res
@@ -14,6 +14,11 @@ module Types = ApolloClient__Testing_Types
 //   children?: any;
 //   link?: ApolloLink;
 // }
+
+/* Then making an ApolloClient in Rescript, additional wrapper methods (e.g. `rescript_query`)
+ * are created for the underlying javascript methods. So for the client to be set up correctly,
+ * we need to do so by calling the rescript method.
+ */
 @react.component
 let make = (
   ~addTypename=true,

--- a/src/@apollo/client/testing/react/ApolloClient__Testing_React_MockedProvider.res
+++ b/src/@apollo/client/testing/react/ApolloClient__Testing_React_MockedProvider.res
@@ -1,0 +1,50 @@
+module InMemoryCache = ApolloClient__Cache_InMemory_InMemoryCache
+module ApolloClient = ApolloClient__Core_ApolloClient
+module ApolloProvider = ApolloClient__React_Context_ApolloProvider
+module Core = ApolloClient__Testing_Core
+module Types = ApolloClient__Testing_Types
+
+// export interface MockedProviderProps<TSerializedCache = {}> {
+//   mocks?: ReadonlyArray<MockedResponse>;
+//   addTypename?: boolean;
+//   defaultOptions?: DefaultOptions;
+//   cache?: ApolloCache<TSerializedCache>;
+//   resolvers?: Resolvers;
+//   childProps?: object;
+//   children?: any;
+//   link?: ApolloLink;
+// }
+@react.component
+let make = (
+  ~addTypename=true,
+  ~cache=?,
+  ~childProps=?,
+  ~children,
+  ~defaultOptions=?,
+  ~link=?,
+  ~mocks: array<Types.mock<'jsVariables>>,
+  ~resolvers=?,
+) => {
+  let client = React.useRef(
+    ApolloClient.make(
+      ~cache=cache->Belt.Option.getWithDefault(InMemoryCache.make(~addTypename, ())),
+      ~defaultOptions?,
+      ~link=link->Belt.Option.getWithDefault(Core.mockLink(~mocks, ~addTypename)),
+      ~resolvers?,
+      (),
+    ),
+  )
+
+  React.useEffect0(() => {
+    Some(client.current.stop)
+  })
+
+  <ApolloProvider client=client.current>
+    {React.cloneElement(
+      React.Children.only(children),
+      childProps->Belt.Option.mapWithDefault(Js.Obj.empty(), props =>
+        Js.Obj.assign(props, Js.Obj.empty())
+      ),
+    )}
+  </ApolloProvider>
+}

--- a/src/ReasonMLCommunity__ApolloClient.res
+++ b/src/ReasonMLCommunity__ApolloClient.res
@@ -64,6 +64,11 @@ module GraphQL_PPX = {
   type templateTagReturnType = ApolloClient__Graphql.documentNode
 }
 
+module Testing = {
+  module MockedProvider = ApolloClient__Testing.MockedProvider
+  let makeResult = ApolloClient__Testing_Types.makeResult
+}
+
 // Convenient access to all types and the methods for working with those types
 module Types = {
   module ApolloError = ApolloClient__Errors_ApolloError


### PR DESCRIPTION
### What
Create `<MockedProvider />` in rescript.

### Why
- We need to create the apollo client in rescript so that methods like `rescript_query` that are added to the client instance are available. 
- We need to serialize the data back to `Js.Json.t` so that we are writing to the apollo cache since cannot write variants to the cache.
- Apollo differentiates `null` and `undefined` when writing to the cache. `None` translates to `undefined`

### How
- Expose `makeResult` method that takes in `toJson` method that knows how to serialize back to `Js.Json.t`. That method is generated as a part of the graphql ppx