### PR TITLE
Implement FieldMerge and FieldMergeFunction

### DIFF
--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies_FieldPolicy.res
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies_FieldPolicy.res
@@ -116,12 +116,12 @@ module FieldMerge = {
     // FieldMergeFunction<TExisting, TIncoming, TOptions> | boolean;
     module FieldMergeUnion: {
       type t<'existing>
-      let mergeFunction: FieldMergeFunction.t<'existing> => t<'existing>
+      let mergeFunction: FieldMergeFunction.Js_.t<'existing> => t<'existing>
       let true_: t<'existing>
     } = {
       @unboxed
       type rec t<'existing> = Any('a): t<'existing>
-      let mergeFunction = (v: FieldMergeFunction.t<'existing>) => Any(v)
+      let mergeFunction = (v: FieldMergeFunction.Js_.t<'existing>) => Any(v)
       let true_ = Any(true)
     }
 
@@ -130,7 +130,8 @@ module FieldMerge = {
 
   let toJs: t<'existing> => Js_.t<'existing> = x =>
     switch x {
-    | MergeFunction(mergeFunction) => mergeFunction->Js_.FieldMergeUnion.mergeFunction
+    | MergeFunction(mergeFunction) =>
+      mergeFunction->FieldMergeFunction.toJs->Js_.FieldMergeUnion.mergeFunction
     | True => Js_.FieldMergeUnion.true_
     }
 }

--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies_FieldPolicy.res
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies_FieldPolicy.res
@@ -4,13 +4,6 @@ module FieldNode = ApolloClient__Graphql.Language.Ast.FieldNode
 module ReadFieldFunction = ApolloClient__Cache_Core_Types_Common.ReadFieldFunction
 module ToReferenceFunction = ApolloClient__Cache_Core_Types_Common.ToReferenceFunction
 
-module FieldMergeFunction = {
-  module Js_ = {
-    type t
-  }
-  type t = Js_.t
-}
-
 module StorageType = {
   type t = Js.Dict.t<Js.Json.t>
   module Js_ = {
@@ -90,6 +83,58 @@ module FieldFunctionOptions = {
   }
 }
 
+module FieldMergeFunction = {
+  type t<'existing> = ('existing, 'existing, FieldFunctionOptions.t) => 'existing
+
+  module Js_ = {
+    //  export type FieldMergeFunction<
+    //    TExisting = any,
+    //    TIncoming = TExisting,
+    //    // Passing the whole FieldFunctionOptions makes the current definition
+    //    // independent from its implementation
+    //    TOptions extends FieldFunctionOptions = FieldFunctionOptions
+    //  > = (
+    //    existing: SafeReadonly<TExisting> | undefined,
+    //    // The incoming parameter needs to be positional as well, for the same
+    //    // reasons discussed in FieldReadFunction above.
+    //    incoming: SafeReadonly<TIncoming>,
+    //    options: TOptions,
+    //  ) => SafeReadonly<TExisting>;
+    type t<'existing> = ('existing, 'existing, FieldFunctionOptions.Js_.t) => 'existing
+  }
+
+  let toJs: t<'existing> => Js_.t<'existing> = (t, existing, incoming, jsFieldFunctionOptions) =>
+    t(existing, incoming, jsFieldFunctionOptions->FieldFunctionOptions.fromJs)
+}
+
+module FieldMerge = {
+  type t<'existing> =
+    | MergeFunction(FieldMergeFunction.t<'existing>)
+    | True
+
+  module Js_ = {
+    // FieldMergeFunction<TExisting, TIncoming, TOptions> | boolean;
+    module FieldMergeUnion: {
+      type t<'existing>
+      let mergeFunction: FieldMergeFunction.t<'existing> => t<'existing>
+      let true_: t<'existing>
+    } = {
+      @unboxed
+      type rec t<'existing> = Any('a): t<'existing>
+      let mergeFunction = (v: FieldMergeFunction.t<'existing>) => Any(v)
+      let true_ = Any(true)
+    }
+
+    type t<'existing> = FieldMergeUnion.t<'existing>
+  }
+
+  let toJs: t<'existing> => Js_.t<'existing> = x =>
+    switch x {
+    | MergeFunction(mergeFunction) => mergeFunction->Js_.FieldMergeUnion.mergeFunction
+    | True => Js_.FieldMergeUnion.true_
+    }
+}
+
 module FieldReadFunction = {
   type t<'existing> = (option<'existing>, FieldFunctionOptions.t) => 'existing
 
@@ -166,7 +211,7 @@ module FieldPolicy = {
   type t<'existing> = {
     keyArgs: option<FieldPolicy_KeyArgs.t>,
     read: option<FieldReadFunction.t<'existing>>,
-    merge: option<FieldMergeFunction.t>,
+    merge: option<FieldMerge.t<'existing>>,
   }
 
   module Js_ = {
@@ -178,13 +223,13 @@ module FieldPolicy = {
     type t<'existing> = {
       keyArgs: option<FieldPolicy_KeyArgs.Js_.t>,
       read: option<FieldReadFunction.Js_.t<'existing>>,
-      merge: option<FieldMergeFunction.Js_.t>,
+      merge: option<FieldMerge.Js_.t<'existing>>,
     }
   }
 
   let toJs: t<'existing> => Js_.t<'existing> = t => {
     keyArgs: t.keyArgs->Belt.Option.map(FieldPolicy_KeyArgs.toJs),
     read: t.read->Belt.Option.map(FieldReadFunction.toJs),
-    merge: t.merge,
+    merge: t.merge->Belt.Option.map(FieldMerge.toJs),
   }
 }


### PR DESCRIPTION
I feel like this is pretty close. Something's wrong with the `@unboxed` though:
```ocaml
  open ApolloClient
  make(
    ~cache=Cache.InMemoryCache.make(
      ~typePolicies=[
        (
          "Trip",
          Cache.InMemoryCache.TypePolicy.make(
            ~fields=[
              (
                "elements",
                FieldPolicy({
                  merge: Some(MergeFunction(incomingMerge)),
                  read: None,
                  keyArgs: None,
                }),
              ),
            ],
            (),
          ),
        ),
```

Compiles to
```javascript
ApolloClient.make(undefined, undefined, undefined, Caml_option.some(httpLink), ApolloClient__Cache_InMemory_InMemoryCache.make(undefined, undefined, undefined, undefined, [
          [
            "Trip",
            ApolloClient__Cache_InMemory_Policies.TypePolicy.make([[
                    "elements",
                    {
                      TAG: /* FieldPolicy */3,
                      _0: {
                        keyArgs: undefined,
                        read: undefined,
                        merge: /* MergeFunction */{
                          _0: incomingMerge
                        }
                      }
                    }
                  ]], undefined, undefined, undefined, undefined, undefined)
          ]
```

How can I get rid of that extra `merge: { _0: incomingMerge }`?