### PR TITLE
BREAKING: convert @obj and @deriving(abstract) to use optional record fields

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 *.re linguist-language=Reason
 *.rei linguist-language=Reason
+*.res linguist-language=ReScript
+*.resi linguist-language=ReScript

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn-error.log
 .vscode/
 lib/
 node_modules/
+.yarn/install-state.gz

--- a/EXAMPLES/bsconfig.json
+++ b/EXAMPLES/bsconfig.json
@@ -20,10 +20,6 @@
     "version": 4,
     "mode": "automatic"
   },
-  "reason": {
-    "react-jsx": 3
-  },
-  "refmt": 3,
   "sources": [
     {
       "dir": "src",

--- a/EXAMPLES/package.json
+++ b/EXAMPLES/package.json
@@ -11,7 +11,7 @@
     "start": "rescript build -with-deps -w"
   },
   "devDependencies": {
-    "@reasonml-community/graphql-ppx": "1.2.3",
+    "@reasonml-community/graphql-ppx": "1.2.4-1345e061.0",
     "graphql-client-example-server": "1.5.2",
     "html-webpack-plugin": "5.5.0",
     "rescript": "10.1.2",

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -6,10 +6,6 @@
       "in-source": true
     }
   ],
-  "reason": {
-    "react-jsx": 3
-  },
-  "refmt": 3,
   "jsx": {
     "version": 4,
     "mode": "automatic"

--- a/package.json
+++ b/package.json
@@ -35,14 +35,10 @@
     "@apollo/client": "^3.5.0",
     "@reasonml-community/graphql-ppx": "^1.0.0",
     "@rescript/react": "~0.10. || ~0.11.0",
-    "bs-platform": "^8.2.0 || ^9.0.0",
-    "rescript": "^9.0.0 || ^10.0.0"
+    "rescript": "^10.0.0"
   },
   "peerDependenciesMeta": {
     "rescript": {
-      "optional": true
-    },
-    "bs-platform": {
       "optional": true
     }
   },

--- a/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.res
+++ b/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.res
@@ -188,9 +188,9 @@ module ApolloCache = {
         ~options={
           id,
           fragment: Fragment.query,
-          fragmentName,
-          optimistic,
-          canonizeResults,
+          ?fragmentName,
+          ?optimistic,
+          ?canonizeResults,
         },
         ~optimistic?,
         (),
@@ -218,11 +218,11 @@ module ApolloCache = {
       ->Js_.readQuery(
         ~options=DataProxy.ReadQueryOptions.toJs(
           {
-            id,
+            ?id,
             query: Operation.query,
             variables,
-            optimistic,
-            canonizeResults,
+            ?optimistic,
+            ?canonizeResults,
           },
           ~mapJsVariables,
           ~serializeVariables=Operation.serializeVariables,
@@ -247,12 +247,12 @@ module ApolloCache = {
       js->Js_.writeFragment(
         ~options=DataProxy.WriteFragmentOptions.toJs(
           {
-            broadcast,
+            ?broadcast,
             data,
             id,
             fragment: Fragment.query,
-            fragmentName,
-            overwrite,
+            ?fragmentName,
+            ?overwrite,
           },
           ~serialize=Fragment.serialize,
         ),
@@ -275,12 +275,12 @@ module ApolloCache = {
       js->Js_.writeQuery(
         ~options=DataProxy.WriteQueryOptions.toJs(
           {
-            broadcast,
+            ?broadcast,
             data,
-            id,
+            ?id,
             query: Operation.query,
             variables,
-            overwrite,
+            ?overwrite,
           },
           ~mapJsVariables,
           ~serialize=Operation.serialize,
@@ -310,13 +310,13 @@ module ApolloCache = {
       ->Js_.updateQuery(
         ~options=DataProxy.UpdateQueryOptions.toJs(
           {
-            optimistic,
-            canonizeResults,
-            broadcast,
-            id,
+            ?optimistic,
+            ?canonizeResults,
+            ?broadcast,
+            ?id,
             query: Operation.query,
             variables,
-            overwrite,
+            ?overwrite,
           },
           ~mapJsVariables,
           ~serializeVariables=Operation.serializeVariables,
@@ -350,13 +350,13 @@ module ApolloCache = {
       js
       ->Js_.updateFragment(
         ~options=DataProxy.UpdateFragmentOptions.toJs({
-          optimistic,
-          canonizeResults,
-          broadcast,
+          ?optimistic,
+          ?canonizeResults,
+          ?broadcast,
           id,
           fragment: Fragment.query,
-          fragmentName,
-          overwrite,
+          ?fragmentName,
+          ?overwrite,
         }),
         ~update=jsData =>
           jsData

--- a/src/@apollo/client/cache/core/types/ApolloClient__Cache_Core_Types_DataProxy.res
+++ b/src/@apollo/client/cache/core/types/ApolloClient__Cache_Core_Types_DataProxy.res
@@ -17,10 +17,10 @@ module ReadQueryOptions = {
       query: Graphql.documentNode,
       // We don't allow optional variables because it's not typesafe
       variables: 'jsVariables,
-      id: option<string>,
-      // returnPartialData: option<bool>,
-      optimistic: option<bool>,
-      canonizeResults: option<bool>,
+      id?: string,
+      // returnPartialData?: bool,
+      optimistic?: bool,
+      canonizeResults?: bool,
     }
   }
 
@@ -33,10 +33,10 @@ module ReadQueryOptions = {
   ) => Js_.t<'jsVariables> = (t, ~mapJsVariables=Utils.identity, ~serializeVariables) => {
     query: t.query,
     variables: t.variables->serializeVariables->mapJsVariables,
-    id: t.id,
-    // returnPartialData: t.returnPartialData,
-    optimistic: t.optimistic,
-    canonizeResults: t.canonizeResults,
+    id: ?t.id,
+    // returnPartialData: ?t.returnPartialData,
+    optimistic: ?t.optimistic,
+    canonizeResults: ?t.canonizeResults,
   }
 }
 
@@ -58,10 +58,10 @@ module ReadFragmentOptions = {
       fragment: Graphql.documentNode,
       // We don't allow optional variables because it's not typesafe
       // variables: 'jsVariables,
-      fragmentName: option<string>,
-      // returnPartialData: option<bool>,
-      optimistic: option<bool>,
-      canonizeResults: option<bool>,
+      fragmentName?: string,
+      // returnPartialData?: bool,
+      optimistic?: bool,
+      canonizeResults?: bool,
     }
   }
 
@@ -70,10 +70,10 @@ module ReadFragmentOptions = {
     fragment: Graphql.documentNode,
     // We don't allow optional variables because it's not typesafe
     // variables: 'jsVariables,
-    fragmentName: option<string>,
-    // returnPartialData: option<bool>,
-    optimistic: option<bool>,
-    canonizeResults: option<bool>,
+    fragmentName?: string,
+    // returnPartialData?: bool,
+    optimistic?: bool,
+    canonizeResults?: bool,
   }
 }
 
@@ -85,23 +85,23 @@ module WriteQueryOptions = {
     // }
     type t<'jsData, 'jsVariables> = {
       data: 'jsData,
-      broadcast: option<bool>,
-      overwrite: option<bool>,
+      broadcast?: bool,
+      overwrite?: bool,
       // ...extends Query
       query: Graphql.documentNode,
       // We don't allow optional variables because it's not typesafe
       variables: 'jsVariables,
-      id: option<string>,
+      id?: string,
     }
   }
 
   type t<'data, 'variables> = {
     data: 'data,
-    broadcast: option<bool>,
-    overwrite: option<bool>,
+    broadcast?: bool,
+    overwrite?: bool,
     query: Graphql.documentNode,
     variables: 'variables,
-    id: option<string>,
+    id?: string,
   }
 
   let toJs: (
@@ -116,11 +116,11 @@ module WriteQueryOptions = {
     ~serializeVariables,
   ) => {
     data: t.data->serialize,
-    broadcast: t.broadcast,
-    overwrite: t.overwrite,
+    broadcast: ?t.broadcast,
+    overwrite: ?t.overwrite,
     query: t.query,
     variables: t.variables->serializeVariables->mapJsVariables,
-    id: t.id,
+    id: ?t.id,
   }
 }
 
@@ -132,12 +132,12 @@ module WriteFragmentOptions = {
     // }
     type t<'jsData, 'jsVariables> = {
       data: 'jsData,
-      broadcast: option<bool>,
-      overwrite: option<bool>,
+      broadcast?: bool,
+      overwrite?: bool,
       // ...extends Fragment
       id: string,
       fragment: Graphql.documentNode,
-      fragmentName: option<string>,
+      fragmentName?: string,
       // I think fragment variables are still experimental?
       // // We don't allow optional variables because it's not typesafe
       // variables: 'jsVariables,
@@ -146,11 +146,11 @@ module WriteFragmentOptions = {
 
   type t<'data, 'variables> = {
     data: 'data,
-    broadcast: option<bool>,
-    overwrite: option<bool>,
+    broadcast?: bool,
+    overwrite?: bool,
     id: string,
     fragment: Graphql.documentNode,
-    fragmentName: option<string>,
+    fragmentName?: string,
     // variables: 'variables,
   }
 
@@ -161,11 +161,11 @@ module WriteFragmentOptions = {
   ) => // ~serializeVariables: 'variables => 'jsVariables
   Js_.t<'jsData, 'jsVariables> = (t, ~serialize) => {
     data: t.data->serialize,
-    broadcast: t.broadcast,
-    overwrite: t.overwrite,
+    broadcast: ?t.broadcast,
+    overwrite: ?t.overwrite,
     id: t.id,
     fragment: t.fragment,
-    fragmentName: t.fragmentName,
+    fragmentName: ?t.fragmentName,
     // variables: t.variables->serializeVariables->mapJsVariables,
   }
 }
@@ -179,29 +179,29 @@ module UpdateQueryOptions = {
     type t<'jsVariables> = {
       // ReadQueryOptions<TData, TVariables>
       // ...extends Query
-      id: option<string>,
+      id?: string,
       query: Graphql.documentNode,
       // We don't allow optional variables because it's not typesafe
       variables: 'jsVariables,
       // ...extends ReadQueryOptions
-      optimistic: option<bool>,
-      canonizeResults: option<bool>,
+      optimistic?: bool,
+      canonizeResults?: bool,
       // ...extends Omit<WriteQueryOptions, 'data'>
-      // returnPartialData: option<bool>, // Don't believe this is supported by graphql-ppx
-      broadcast: option<bool>,
-      overwrite: option<bool>,
+      // returnPartialData?: bool, // Don't believe this is supported by graphql-ppx
+      broadcast?: bool,
+      overwrite?: bool,
     }
   }
 
   type t<'variables> = {
-    id: option<string>,
+    id?: string,
     query: Graphql.documentNode,
     variables: 'variables,
-    optimistic: option<bool>,
-    canonizeResults: option<bool>,
-    // returnPartialData: option<bool>, // Don't believe this is supported by graphql-ppx
-    broadcast: option<bool>,
-    overwrite: option<bool>,
+    optimistic?: bool,
+    canonizeResults?: bool,
+    // returnPartialData?: bool, // Don't believe this is supported by graphql-ppx
+    broadcast?: bool,
+    overwrite?: bool,
   }
 
   let toJs: (
@@ -209,14 +209,14 @@ module UpdateQueryOptions = {
     ~mapJsVariables: 'jsVariables => 'jsVariables=?,
     ~serializeVariables: 'variables => 'jsVariables,
   ) => Js_.t<'jsVariables> = (t, ~mapJsVariables=Utils.identity, ~serializeVariables) => {
-    id: t.id,
+    id: ?t.id,
     query: t.query,
     variables: t.variables->serializeVariables->mapJsVariables,
-    optimistic: t.optimistic,
-    canonizeResults: t.canonizeResults,
-    broadcast: t.broadcast,
-    overwrite: t.overwrite,
-    // returnPartialData: t.returnPartialData, // Don't believe this is supported by graphql-ppx
+    optimistic: ?t.optimistic,
+    canonizeResults: ?t.canonizeResults,
+    broadcast: ?t.broadcast,
+    overwrite: ?t.overwrite,
+    // returnPartialData: ?t.returnPartialData, // Don't believe this is supported by graphql-ppx
   }
 }
 
@@ -231,40 +231,40 @@ module UpdateFragmentOptions = {
       // ...extends Fragment
       id: string,
       fragment: Graphql.documentNode,
-      fragmentName: option<string>,
+      fragmentName?: string,
       // We don't allow optional variables because it's not typesafe
       // variables: 'jsVariables,
       // ...extends ReadFragmentOptions
-      optimistic: option<bool>,
-      canonizeResults: option<bool>,
+      optimistic?: bool,
+      canonizeResults?: bool,
       // ...extends Omit<WriteFragmentOptions, 'data'>
-      // returnPartialData: option<bool>, // Don't believe this is supported by graphql-ppx
-      broadcast: option<bool>,
-      overwrite: option<bool>,
+      // returnPartialData?: bool, // Don't believe this is supported by graphql-ppx
+      broadcast?: bool,
+      overwrite?: bool,
     }
   }
 
   type t<'variables> = {
     id: string,
     fragment: Graphql.documentNode,
-    fragmentName: option<string>,
+    fragmentName?: string,
     // variables: 'variables,
-    optimistic: option<bool>,
-    canonizeResults: option<bool>,
-    // returnPartialData: option<bool>, // Don't believe this is supported by graphql-ppx
-    broadcast: option<bool>,
-    overwrite: option<bool>,
+    optimistic?: bool,
+    canonizeResults?: bool,
+    // returnPartialData?: bool, // Don't believe this is supported by graphql-ppx
+    broadcast?: bool,
+    overwrite?: bool,
   }
 
   let toJs: t<'variables> => Js_.t<'jsVariables> = t => {
     id: t.id,
     fragment: t.fragment,
-    fragmentName: t.fragmentName,
+    fragmentName: ?t.fragmentName,
     // variables: t.variables,
-    optimistic: t.optimistic,
-    canonizeResults: t.canonizeResults,
-    broadcast: t.broadcast,
-    overwrite: t.overwrite,
+    optimistic: ?t.optimistic,
+    canonizeResults: ?t.canonizeResults,
+    broadcast: ?t.broadcast,
+    overwrite: ?t.overwrite,
     // returnPartialData: t.returnPartialData, // Don't believe this is supported by graphql-ppx
   }
 }

--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_InMemoryCache.res
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_InMemoryCache.res
@@ -11,24 +11,16 @@ module InMemoryCacheConfig = {
     //     possibleTypes?: PossibleTypesMap;
     //     typePolicies?: TypePolicies;
     // }
-    // NOTE: Using deriving abstract here because passing properties that are undefined has effects
-    @deriving(abstract)
     type t = {
-      @optional
-      resultCaching: bool,
-      @optional
-      possibleTypes: PossibleTypesMap.Js_.t,
-      @optional
-      typePolicies: TypePolicies.Js_.t,
+      resultCaching?: bool,
+      possibleTypes?: PossibleTypesMap.Js_.t,
+      typePolicies?: TypePolicies.Js_.t,
       // ...extends ApolloReducerConfig
-      @optional
-      dataIdFromObject: KeyFieldsFunction.Js_.t,
-      @optional
-      addTypename: bool,
+      dataIdFromObject?: KeyFieldsFunction.Js_.t,
+      addTypename?: bool,
     }
   }
   type t = Js_.t
-  let make = Js_.t
 }
 
 module Js_ = {
@@ -88,13 +80,10 @@ let make: (
   ~typePolicies=?,
   (),
 ) =>
-  Js_.make(
-    InMemoryCacheConfig.make(
-      ~addTypename?,
-      ~dataIdFromObject?,
-      ~possibleTypes?,
-      ~resultCaching?,
-      ~typePolicies=?typePolicies->Belt.Option.map(TypePolicies.toJs),
-      (),
-    ),
-  )->ApolloCache.fromJs
+  Js_.make({
+    ?addTypename,
+    ?dataIdFromObject,
+    ?possibleTypes,
+    ?resultCaching,
+    typePolicies: ?typePolicies->Belt.Option.map(TypePolicies.toJs),
+  })->ApolloCache.fromJs

--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies.res
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies.res
@@ -9,24 +9,10 @@ module SelectionSetNode = ApolloClient__Graphql.Language.Ast.SelectionSetNode
 
 module KeyFieldsContext = {
   type t = {
-    typename: option<string>,
-    selectionSet: option<SelectionSetNode.t>,
-    fragment: option<FragmentMap.t>,
-    keyObject: option<Js.Json.t>,
-  }
-  module Js_ = {
-    // declare type KeyFieldsContext = {
-    //     typename?: string;
-    //     selectionSet?: SelectionSetNode;
-    //     fragmentMap?: FragmentMap;
-    //     keyObject?: Record<string, any>;
-    // };
-    type t = t = {
-      typename: option<string>,
-      selectionSet: option<SelectionSetNode.t>,
-      fragment: option<FragmentMap.Js_.t>,
-      keyObject: option<Js.Json.t>,
-    }
+    typename?: string,
+    selectionSet?: SelectionSetNode.t,
+    fragment?: FragmentMap.t,
+    keyObject?: Js.Json.t,
   }
 }
 
@@ -65,11 +51,11 @@ module TypePolicy = {
     //     };
     // };
     type t = {
-      keyFields: option<KeyArgs.Js_.t>,
-      queryType: option<bool>,
-      mutationType: option<bool>,
-      subscriptionType: option<bool>,
-      fields: option<Js.Dict.t<FieldsUnion.t>>,
+      keyFields?: KeyArgs.Js_.t,
+      queryType?: bool,
+      mutationType?: bool,
+      subscriptionType?: bool,
+      fields?: Js.Dict.t<FieldsUnion.t>,
     }
   }
 
@@ -85,19 +71,19 @@ module TypePolicy = {
   type t_fields = array<(fieldKey, t_field)>
 
   type t = {
-    keyFields: option<KeyArgs.t>,
-    queryType: option<bool>,
-    mutationType: option<bool>,
-    subscriptionType: option<bool>,
-    fields: option<t_fields>,
+    keyFields?: KeyArgs.t,
+    queryType?: bool,
+    mutationType?: bool,
+    subscriptionType?: bool,
+    fields?: t_fields,
   }
 
-  let toJs: (. t) => Js_.t = (. t) => {
-    keyFields: t.keyFields->Belt.Option.map(KeyArgs.toJs),
-    queryType: t.queryType,
-    mutationType: t.mutationType,
-    subscriptionType: t.subscriptionType,
-    fields: t.fields->Belt.Option.map(fields =>
+  let toJs: t => Js_.t = t => {
+    keyFields: ?t.keyFields->Belt.Option.map(KeyArgs.toJs),
+    queryType: ?t.queryType,
+    mutationType: ?t.mutationType,
+    subscriptionType: ?t.subscriptionType,
+    fields: ?t.fields->Belt.Option.map(fields =>
       fields
       ->Belt.Array.map(((fieldKey, t_field)) => (
         fieldKey,
@@ -118,6 +104,7 @@ module TypePolicy = {
     ),
   }
 
+  @deprecated("Construct the record directly instead")
   let make: (
     ~fields: t_fields=?,
     ~keyFields: KeyArgs.t=?,
@@ -126,11 +113,11 @@ module TypePolicy = {
     ~subscriptionType: bool=?,
     unit,
   ) => t = (~fields=?, ~keyFields=?, ~mutationType=?, ~queryType=?, ~subscriptionType=?, ()) => {
-    fields,
-    keyFields,
-    mutationType,
-    queryType,
-    subscriptionType,
+    ?fields,
+    ?keyFields,
+    ?mutationType,
+    ?queryType,
+    ?subscriptionType,
   }
 }
 
@@ -147,7 +134,7 @@ module TypePolicies = {
   type t = array<(typename, TypePolicy.t)>
 
   let toJs: t => Js_.t = t =>
-    t->Belt.Array.map(((key, policy)) => (key, TypePolicy.toJs(. policy)))->Js.Dict.fromArray
+    t->Belt.Array.map(((key, policy)) => (key, TypePolicy.toJs(policy)))->Js.Dict.fromArray
 }
 
 module PossibleTypesMap = {

--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies_FieldPolicy.res
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies_FieldPolicy.res
@@ -210,9 +210,9 @@ module FieldPolicy_KeyArgs = {
 
 module FieldPolicy = {
   type t<'existing> = {
-    keyArgs: option<FieldPolicy_KeyArgs.t>,
-    read: option<FieldReadFunction.t<'existing>>,
-    merge: option<FieldMerge.t<'existing>>,
+    keyArgs?: FieldPolicy_KeyArgs.t,
+    read?: FieldReadFunction.t<'existing>,
+    merge?: FieldMerge.t<'existing>,
   }
 
   module Js_ = {
@@ -222,15 +222,15 @@ module FieldPolicy = {
     //     merge?: FieldMergeFunction<TExisting, TIncoming> | boolean;
     // };
     type t<'existing> = {
-      keyArgs: option<FieldPolicy_KeyArgs.Js_.t>,
-      read: option<FieldReadFunction.Js_.t<'existing>>,
-      merge: option<FieldMerge.Js_.t<'existing>>,
+      keyArgs?: FieldPolicy_KeyArgs.Js_.t,
+      read?: FieldReadFunction.Js_.t<'existing>,
+      merge?: FieldMerge.Js_.t<'existing>,
     }
   }
 
   let toJs: t<'existing> => Js_.t<'existing> = t => {
-    keyArgs: t.keyArgs->Belt.Option.map(FieldPolicy_KeyArgs.toJs),
-    read: t.read->Belt.Option.map(FieldReadFunction.toJs),
-    merge: t.merge->Belt.Option.map(FieldMerge.toJs),
+    keyArgs: ?t.keyArgs->Belt.Option.map(FieldPolicy_KeyArgs.toJs),
+    read: ?t.read->Belt.Option.map(FieldReadFunction.toJs),
+    merge: ?t.merge->Belt.Option.map(FieldMerge.toJs),
   }
 }

--- a/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
+++ b/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
@@ -33,30 +33,31 @@ module DefaultWatchQueryOptions = {
   module Js_ = {
     // Partial<QueryOptions>;
     type t = {
-      fetchPolicy: option<WatchQueryFetchPolicy.Js_.t>,
+      fetchPolicy?: WatchQueryFetchPolicy.Js_.t,
       // query: GraphQL.Language.documentNode,
-      // variables: option('jsVariables),
-      errorPolicy: option<ErrorPolicy.Js_.t>,
-      context: option<Js.Json.t>,
+      // variables?: 'jsVariables,
+      errorPolicy?: ErrorPolicy.Js_.t,
+      context?: Js.Json.t,
     }
   }
 
   type t = {
-    fetchPolicy: option<WatchQueryFetchPolicy.t>,
-    errorPolicy: option<ErrorPolicy.t>,
-    context: option<Js.Json.t>,
+    fetchPolicy?: WatchQueryFetchPolicy.t,
+    errorPolicy?: ErrorPolicy.t,
+    context?: Js.Json.t,
   }
 
   let toJs: t => Js_.t = t => {
-    fetchPolicy: t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
-    errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-    context: t.context,
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
+    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    context: ?t.context,
   }
 
+  @deprecated("Just construct t instead")
   let make = (~fetchPolicy=?, ~errorPolicy=?, ~context=?, ()) => {
-    fetchPolicy,
-    errorPolicy,
-    context,
+    ?fetchPolicy,
+    ?errorPolicy,
+    ?context,
   }
 }
 
@@ -64,30 +65,37 @@ module DefaultQueryOptions = {
   module Js_ = {
     // Partial<QueryOptions>;
     type t = {
-      fetchPolicy: option<FetchPolicy.Js_.t>,
+      fetchPolicy?: FetchPolicy.Js_.t,
       // query: GraphQL.Language.documentNode,
-      // variables: option('jsVariables),
-      errorPolicy: option<ErrorPolicy.Js_.t>,
-      context: option<Js.Json.t>,
+      // variables?: 'jsVariables,
+      errorPolicy?: ErrorPolicy.Js_.t,
+      context?: Js.Json.t,
     }
   }
 
   type t = {
-    fetchPolicy: option<FetchPolicy.t>,
-    errorPolicy: option<ErrorPolicy.t>,
-    context: option<Js.Json.t>,
+    fetchPolicy?: FetchPolicy.t,
+    errorPolicy?: ErrorPolicy.t,
+    context?: Js.Json.t,
   }
 
   let toJs: t => Js_.t = t => {
-    fetchPolicy: t.fetchPolicy->Belt.Option.map(FetchPolicy.toJs),
-    errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-    context: t.context,
+    fetchPolicy: ?switch t.fetchPolicy {
+    | Some(fetchPolicy) => FetchPolicy.toJs(fetchPolicy)->Some
+    | None => None
+    },
+    errorPolicy: ?switch t.errorPolicy {
+    | Some(errorPolicy) => ErrorPolicy.toJs(errorPolicy)->Some
+    | None => None
+    },
+    context: ?t.context,
   }
 
+  @deprecated("Just construct t instead")
   let make = (~fetchPolicy=?, ~errorPolicy=?, ~context=?, ()) => {
-    fetchPolicy,
-    errorPolicy,
-    context,
+    ?fetchPolicy,
+    ?errorPolicy,
+    ?context,
   }
 }
 
@@ -95,34 +103,35 @@ module DefaultMutateOptions = {
   module Js_ = {
     // Partial<MutationOptions>;
     type t = {
-      context: option<Js.Json.t>,
-      fetchPolicy: option<FetchPolicy__noCacheExtracted.Js_.t>,
-      awaitRefetchQueries: option<bool>,
-      errorPolicy: option<ErrorPolicy.Js_.t>,
-      // optimisticResponse: option('jsVariables => 'jsData),
-      // update: option(MutationUpdaterFn.Js_.t('jsData)),
-      // updateQueries: option(MutationQueryReducersMap.Js_.t('jsData)),
-      refetchQueries: option<RefetchQueryDescription.Js_.t>,
-      // variables: option('jsVariables),
+      context?: Js.Json.t,
+      fetchPolicy?: FetchPolicy__noCacheExtracted.Js_.t,
+      awaitRefetchQueries?: bool,
+      errorPolicy?: ErrorPolicy.Js_.t,
+      // optimisticResponse?: 'jsVariables => 'jsData,
+      // update?: MutationUpdaterFn.Js_.t<'jsData>,
+      // updateQueries?: MutationQueryReducersMap.Js_.t<'jsData>,
+      refetchQueries?: RefetchQueryDescription.Js_.t,
+      // variables?: 'jsVariables,
     }
   }
 
   type t = {
-    context: option<Js.Json.t>,
-    fetchPolicy: option<FetchPolicy__noCacheExtracted.t>,
-    awaitRefetchQueries: option<bool>,
-    errorPolicy: option<ErrorPolicy.t>,
-    refetchQueries: option<RefetchQueryDescription.t>,
+    context?: Js.Json.t,
+    fetchPolicy?: FetchPolicy__noCacheExtracted.t,
+    awaitRefetchQueries?: bool,
+    errorPolicy?: ErrorPolicy.t,
+    refetchQueries?: RefetchQueryDescription.t,
   }
 
   let toJs: t => Js_.t = t => {
-    context: t.context,
-    fetchPolicy: t.fetchPolicy->Belt.Option.map(FetchPolicy__noCacheExtracted.toJs),
-    awaitRefetchQueries: t.awaitRefetchQueries,
-    errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-    refetchQueries: t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
+    context: ?t.context,
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(FetchPolicy__noCacheExtracted.toJs),
+    awaitRefetchQueries: ?t.awaitRefetchQueries,
+    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    refetchQueries: ?t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
   }
 
+  @deprecated("Just construct instead")
   let make = (
     ~context=?,
     ~fetchPolicy=?,
@@ -131,11 +140,11 @@ module DefaultMutateOptions = {
     ~refetchQueries=?,
     (),
   ) => {
-    context,
-    fetchPolicy,
-    awaitRefetchQueries,
-    errorPolicy,
-    refetchQueries,
+    ?context,
+    ?fetchPolicy,
+    ?awaitRefetchQueries,
+    ?errorPolicy,
+    ?refetchQueries,
   }
 }
 
@@ -147,33 +156,34 @@ module DefaultOptions = {
     //     mutate?: Partial<MutationOptions>;
     // }
     type t = {
-      watchQuery: option<DefaultWatchQueryOptions.Js_.t>,
-      query: option<DefaultQueryOptions.Js_.t>,
-      mutate: option<DefaultMutateOptions.Js_.t>,
+      watchQuery?: DefaultWatchQueryOptions.Js_.t,
+      query?: DefaultQueryOptions.Js_.t,
+      mutate?: DefaultMutateOptions.Js_.t,
     }
   }
 
   type t = {
-    watchQuery: option<DefaultWatchQueryOptions.t>,
-    query: option<DefaultQueryOptions.t>,
-    mutate: option<DefaultMutateOptions.t>,
+    watchQuery?: DefaultWatchQueryOptions.t,
+    query?: DefaultQueryOptions.t,
+    mutate?: DefaultMutateOptions.t,
   }
 
   let toJs: t => Js_.t = t => {
-    watchQuery: t.watchQuery->Belt.Option.map(DefaultWatchQueryOptions.toJs),
-    query: t.query->Belt.Option.map(DefaultQueryOptions.toJs),
-    mutate: t.mutate->Belt.Option.map(DefaultMutateOptions.toJs),
+    watchQuery: ?t.watchQuery->Belt.Option.map(DefaultWatchQueryOptions.toJs),
+    query: ?t.query->Belt.Option.map(DefaultQueryOptions.toJs),
+    mutate: ?t.mutate->Belt.Option.map(DefaultMutateOptions.toJs),
   }
 
+  @deprecated("Just construct instead")
   let make: (
     ~mutate: DefaultMutateOptions.t=?,
     ~query: DefaultQueryOptions.t=?,
     ~watchQuery: DefaultWatchQueryOptions.t=?,
     unit,
   ) => t = (~mutate=?, ~query=?, ~watchQuery=?, ()) => {
-    watchQuery,
-    query,
-    mutate,
+    ?watchQuery,
+    ?query,
+    ?mutate,
   }
 }
 
@@ -198,61 +208,61 @@ module ApolloClientOptions = {
     //     version?: string;
     // };
     type t = {
-      uri: option<UriFunction.Js_.t>,
-      credentials: option<string>,
-      headers: option<Js.Dict.t<string>>,
-      link: option<ApolloLink.Js_.t>,
+      uri?: UriFunction.Js_.t,
+      credentials?: string,
+      headers?: Js.Dict.t<string>,
+      link?: ApolloLink.Js_.t,
       cache: ApolloCache.t<Js.Json.t>, // Non-Js_ ApolloCache is correct here
-      ssrForceFetchDelay: option<int>,
-      ssrMode: option<bool>,
-      connectToDevTools: option<bool>,
-      queryDeduplication: option<bool>,
-      defaultOptions: option<DefaultOptions.Js_.t>,
-      assumeImmutableResults: option<bool>,
-      resolvers: option<array<Resolvers.Js_.t>>,
-      typeDefs: option<array<Graphql.documentNode>>,
-      fragmentMatcher: option<FragmentMatcher.Js_.t>,
-      name: option<string>,
-      version: option<string>,
+      ssrForceFetchDelay?: int,
+      ssrMode?: bool,
+      connectToDevTools?: bool,
+      queryDeduplication?: bool,
+      defaultOptions?: DefaultOptions.Js_.t,
+      assumeImmutableResults?: bool,
+      resolvers?: array<Resolvers.Js_.t>,
+      typeDefs?: array<Graphql.documentNode>,
+      fragmentMatcher?: FragmentMatcher.Js_.t,
+      name?: string,
+      version?: string,
     }
   }
 
   type t = {
-    uri: option<UriFunction.t>,
-    credentials: option<string>,
-    headers: option<Js.Dict.t<string>>,
-    link: option<ApolloLink.t>,
+    uri?: UriFunction.t,
+    credentials?: string,
+    headers?: Js.Dict.t<string>,
+    link?: ApolloLink.t,
     cache: ApolloCache.t<Js.Json.t>,
-    ssrForceFetchDelay: option<int>,
-    ssrMode: option<bool>,
-    connectToDevTools: option<bool>,
-    queryDeduplication: option<bool>,
-    defaultOptions: option<DefaultOptions.t>,
-    assumeImmutableResults: option<bool>,
-    resolvers: option<array<Resolvers.t>>,
-    typeDefs: option<array<Graphql.documentNode>>,
-    fragmentMatcher: option<FragmentMatcher.t>,
-    name: option<string>,
-    version: option<string>,
+    ssrForceFetchDelay?: int,
+    ssrMode?: bool,
+    connectToDevTools?: bool,
+    queryDeduplication?: bool,
+    defaultOptions?: DefaultOptions.t,
+    assumeImmutableResults?: bool,
+    resolvers?: array<Resolvers.t>,
+    typeDefs?: array<Graphql.documentNode>,
+    fragmentMatcher?: FragmentMatcher.t,
+    name?: string,
+    version?: string,
   }
 
   let toJs: t => Js_.t = t => {
-    uri: t.uri,
-    credentials: t.credentials,
-    headers: t.headers,
-    link: t.link,
+    uri: ?t.uri,
+    credentials: ?t.credentials,
+    headers: ?t.headers,
+    link: ?t.link,
     cache: t.cache,
-    ssrForceFetchDelay: t.ssrForceFetchDelay,
-    ssrMode: t.ssrMode,
-    connectToDevTools: t.connectToDevTools,
-    queryDeduplication: t.queryDeduplication,
-    defaultOptions: t.defaultOptions->Belt.Option.map(DefaultOptions.toJs),
-    assumeImmutableResults: t.assumeImmutableResults,
-    resolvers: t.resolvers,
-    typeDefs: t.typeDefs,
-    fragmentMatcher: t.fragmentMatcher,
-    name: t.name,
-    version: t.version,
+    ssrForceFetchDelay: ?t.ssrForceFetchDelay,
+    ssrMode: ?t.ssrMode,
+    connectToDevTools: ?t.connectToDevTools,
+    queryDeduplication: ?t.queryDeduplication,
+    defaultOptions: ?t.defaultOptions->Belt.Option.map(DefaultOptions.toJs),
+    assumeImmutableResults: ?t.assumeImmutableResults,
+    resolvers: ?t.resolvers,
+    typeDefs: ?t.typeDefs,
+    fragmentMatcher: ?t.fragmentMatcher,
+    name: ?t.name,
+    version: ?t.version,
   }
 }
 
@@ -610,22 +620,22 @@ let make: (
 ) => {
   let jsClient = Js_.make(
     ApolloClientOptions.toJs({
-      uri,
-      credentials,
-      headers,
-      link,
+      ?uri,
+      ?credentials,
+      ?headers,
+      ?link,
       cache,
-      ssrForceFetchDelay,
-      ssrMode,
-      connectToDevTools,
-      queryDeduplication,
-      defaultOptions,
-      assumeImmutableResults,
-      resolvers,
-      typeDefs,
-      fragmentMatcher,
-      name,
-      version,
+      ?ssrForceFetchDelay,
+      ?ssrMode,
+      ?connectToDevTools,
+      ?queryDeduplication,
+      ?defaultOptions,
+      ?assumeImmutableResults,
+      ?resolvers,
+      ?typeDefs,
+      ?fragmentMatcher,
+      ?name,
+      ?version,
     }),
   )
 
@@ -661,15 +671,15 @@ let make: (
       jsClient,
       ~options=MutationOptions.toJs(
         {
-          awaitRefetchQueries,
-          context,
-          errorPolicy,
-          fetchPolicy,
+          ?awaitRefetchQueries,
+          ?context,
+          ?errorPolicy,
+          ?fetchPolicy,
           mutation: Operation.query,
-          optimisticResponse,
-          updateQueries,
-          refetchQueries,
-          update,
+          ?optimisticResponse,
+          ?updateQueries,
+          ?refetchQueries,
+          ?update,
           variables,
         },
         ~mapJsVariables,
@@ -721,11 +731,11 @@ let make: (
       jsClient,
       ~options=QueryOptions.toJs(
         {
-          fetchPolicy,
+          ?fetchPolicy,
           query: Operation.query,
           variables,
-          errorPolicy,
-          context,
+          ?errorPolicy,
+          ?context,
         },
         ~mapJsVariables,
         ~serializeVariables=Operation.serializeVariables,
@@ -769,9 +779,9 @@ let make: (
       ~options={
         id,
         fragment: Fragment.query,
-        fragmentName,
-        optimistic,
-        canonizeResults,
+        ?fragmentName,
+        ?optimistic,
+        ?canonizeResults,
       },
       ~optimistic?,
       (),
@@ -799,11 +809,11 @@ let make: (
       jsClient,
       ~options=DataProxy.ReadQueryOptions.toJs(
         {
-          id,
+          ?id,
           query: Operation.query,
           variables,
-          optimistic,
-          canonizeResults,
+          ?optimistic,
+          ?canonizeResults,
         },
         ~mapJsVariables,
         ~serializeVariables=Operation.serializeVariables,
@@ -848,11 +858,11 @@ let make: (
       jsClient,
       ~options=SubscriptionOptions.toJs(
         {
-          fetchPolicy,
+          ?fetchPolicy,
           query: Operation.query,
           variables,
-          errorPolicy,
-          context,
+          ?errorPolicy,
+          ?context,
         },
         ~mapJsVariables,
         ~serializeVariables=Operation.serializeVariables,
@@ -904,13 +914,13 @@ let make: (
     ->Js_.watchQuery(
       ~options=WatchQueryOptions.toJs(
         {
-          fetchPolicy,
-          nextFetchPolicy,
+          ?fetchPolicy,
+          ?nextFetchPolicy,
           query: Operation.query,
           variables,
-          errorPolicy,
-          context,
-          pollInterval,
+          ?errorPolicy,
+          ?context,
+          ?pollInterval,
         },
         ~mapJsVariables,
         ~serializeVariables=Operation.serializeVariables,
@@ -932,12 +942,12 @@ let make: (
     jsClient->Js_.writeFragment(
       ~options=DataProxy.WriteFragmentOptions.toJs(
         {
-          broadcast,
+          ?broadcast,
           data,
           id,
           fragment: Fragment.query,
-          fragmentName,
-          overwrite,
+          ?fragmentName,
+          ?overwrite,
         },
         ~serialize=Fragment.serialize,
       ),
@@ -960,12 +970,12 @@ let make: (
     jsClient->Js_.writeQuery(
       ~options=DataProxy.WriteQueryOptions.toJs(
         {
-          broadcast,
+          ?broadcast,
           data,
-          id,
+          ?id,
           query: Operation.query,
           variables,
-          overwrite,
+          ?overwrite,
         },
         ~mapJsVariables,
         ~serialize=Operation.serialize,
@@ -995,13 +1005,13 @@ let make: (
     ->Js_.updateQuery(
       ~options=DataProxy.UpdateQueryOptions.toJs(
         {
-          optimistic,
-          canonizeResults,
-          broadcast,
-          id,
+          ?optimistic,
+          ?canonizeResults,
+          ?broadcast,
+          ?id,
           query: Operation.query,
           variables,
-          overwrite,
+          ?overwrite,
         },
         ~mapJsVariables,
         ~serializeVariables=Operation.serializeVariables,
@@ -1035,13 +1045,13 @@ let make: (
     jsClient
     ->Js_.updateFragment(
       ~options=DataProxy.UpdateFragmentOptions.toJs({
-        optimistic,
-        canonizeResults,
-        broadcast,
+        ?optimistic,
+        ?canonizeResults,
+        ?broadcast,
         id,
         fragment: Fragment.query,
-        fragmentName,
-        overwrite,
+        ?fragmentName,
+        ?overwrite,
       }),
       ~update=jsData =>
         jsData

--- a/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.res
+++ b/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.res
@@ -52,13 +52,14 @@ module ObservableQuery = {
     // ...extends Observable<ApolloQueryResult<TData>>
     // <R>(callback: (value: T) => R): Observable<R>;
     @send external map: (t<'t>, 't => 'r) => t<'r> = "map"
+
+    /**
+    We should be able to just map, but it's broken:
+    https://github.com/apollographql/apollo-client/issues/6144
+    This is not any sort of real map, of course. It just returns an observable
+    with a subcribe method that builds the transformation into onNext :(
+    */
     let fakeMap: (t<'t>, ('t, Js.Exn.t => unit) => option<'r>) => t<'r> = (js, fn) =>
-      @ocaml.doc("
-          * We should be able to just map, but it's broken:
-          * https://github.com/apollographql/apollo-client/issues/6144
-          * This is not any sort of real map, of course. It just returns an observable
-          * with a subcribe method that builds the transformation into onNext :(
-          ")
       %raw(`
             function (js, fn) {
               var originalSubscribe = js.subscribe.bind(js);

--- a/src/@apollo/client/core/ApolloClient__Core_Types.res
+++ b/src/@apollo/client/core/ApolloClient__Core_Types.res
@@ -27,20 +27,20 @@ module PureQueryOptions = {
       query: Graphql.documentNode,
       // We don't allow optional variables because it's not typesafe
       variables: 'jsVariables,
-      context: option<Js.Json.t>,
+      context?: Js.Json.t,
     }
   }
 
   type t<'jsVariables> = {
     query: Graphql.documentNode,
     variables: 'jsVariables,
-    context: option<Js.Json.t>,
+    context?: Js.Json.t,
   }
 
   let toJs: t<'jsVariables> => Js_.t<'jsVariables> = t => {
     query: t.query,
     variables: t.variables,
-    context: t.context,
+    context: ?t.context,
   }
 }
 
@@ -136,7 +136,7 @@ module MutationQueryReducer = {
       queryVariables: Js.Json.t, // ACTUAL: Record<string, any>
     }
 
-    type t<'jsData> = (. Js.Json.t, options<'jsData>) => Js.Json.t
+    type t<'jsData> = (Js.Json.t, options<'jsData>) => Js.Json.t
   }
 
   type options<'data> = {
@@ -150,16 +150,17 @@ module MutationQueryReducer = {
   let toJs: (
     t<'data>,
     ~safeParse: Types.safeParse<'data, 'jsData>,
-  ) => (. Js.Json.t, Js_.options<'jsData>) => Js.Json.t = (t, ~safeParse) =>
-    (. previousResult, jsOptions) =>
-      t(
-        previousResult,
-        {
-          mutationResult: jsOptions.mutationResult->FetchResult.fromJs(~safeParse),
-          queryName: jsOptions.queryName,
-          queryVariables: jsOptions.queryVariables,
-        },
-      )
+    Js.Json.t,
+    Js_.options<'jsData>,
+  ) => Js.Json.t = (t, ~safeParse, previousResult, jsOptions) =>
+    t(
+      previousResult,
+      {
+        mutationResult: jsOptions.mutationResult->FetchResult.fromJs(~safeParse),
+        queryName: jsOptions.queryName,
+        queryVariables: jsOptions.queryVariables,
+      },
+    )
 }
 
 module MutationQueryReducersMap = {

--- a/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.res
+++ b/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.res
@@ -8,7 +8,7 @@ module PureQueryOptions = ApolloClient__Core_Types.PureQueryOptions
 module ErrorPolicy = {
   module Js_ = {
     // export declare type ErrorPolicy = 'none' | 'ignore' | 'all';
-    type t = string
+    type t = [#none | #ignore | #all]
   }
 
   type t =
@@ -18,16 +18,16 @@ module ErrorPolicy = {
 
   let toJs = x =>
     switch x {
-    | None => "none"
-    | Ignore => "ignore"
-    | All => "all"
+    | None => #none
+    | Ignore => #ignore
+    | All => #all
     }
 }
 
 module FetchPolicy = {
   module Js_ = {
     // export declare type FetchPolicy = 'cache-first' | 'network-only' | 'cache-only' | 'no-cache' | 'standby';
-    type t = string
+    type t = [#"cache-first" | #"network-only" | #"cache-only" | #"no-cache" | #standby]
   }
 
   type t =
@@ -37,13 +37,13 @@ module FetchPolicy = {
     | NoCache
     | Standby
 
-  let toJs = x =>
+  let toJs = (x): Js_.t =>
     switch x {
-    | CacheFirst => "cache-first"
-    | CacheOnly => "cache-only"
-    | NetworkOnly => "network-only"
-    | NoCache => "no-cache"
-    | Standby => "standby"
+    | CacheFirst => #"cache-first"
+    | CacheOnly => #"cache-only"
+    | NetworkOnly => #"network-only"
+    | NoCache => #"no-cache"
+    | Standby => #standby
     }
 }
 
@@ -63,7 +63,7 @@ module FetchPolicy__noCacheExtracted = {
 module WatchQueryFetchPolicy = {
   module Js_ = {
     // export declare type WatchQueryFetchPolicy = FetchPolicy | 'cache-and-network';
-    type t = string
+    type t = [FetchPolicy.Js_.t | #"cache-and-network"]
   }
 
   type t =
@@ -74,36 +74,36 @@ module WatchQueryFetchPolicy = {
     | NoCache
     | Standby
 
-  let toJs = x =>
+  let toJs = (x): Js_.t =>
     switch x {
-    | CacheAndNetwork => "cache-and-network"
-    | CacheFirst => "cache-first"
-    | CacheOnly => "cache-only"
-    | NetworkOnly => "network-only"
-    | NoCache => "no-cache"
-    | Standby => "standby"
+    | CacheAndNetwork => #"cache-and-network"
+    | CacheFirst => #"cache-first"
+    | CacheOnly => #"cache-only"
+    | NetworkOnly => #"network-only"
+    | NoCache => #"no-cache"
+    | Standby => #standby
     }
 }
 
 module QueryOptions = {
   module Js_ = {
     type t<'jsVariables> = {
-      fetchPolicy: option<FetchPolicy.Js_.t>,
+      fetchPolicy?: FetchPolicy.Js_.t,
       // ...extends QueryBaseOptions
       query: Graphql.documentNode,
       // We don't allow optional variables because it's not typesafe
       variables: 'jsVariables,
-      errorPolicy: option<ErrorPolicy.Js_.t>,
-      context: option<Js.Json.t>,
+      errorPolicy?: ErrorPolicy.Js_.t,
+      context?: Js.Json.t,
     }
   }
 
   type t<'jsVariables> = {
-    fetchPolicy: option<FetchPolicy.t>,
+    fetchPolicy?: FetchPolicy.t,
     query: Graphql.documentNode,
     variables: 'jsVariables,
-    errorPolicy: option<ErrorPolicy.t>,
-    context: option<Js.Json.t>,
+    errorPolicy?: ErrorPolicy.t,
+    context?: Js.Json.t,
   }
 
   let toJs: (
@@ -111,37 +111,37 @@ module QueryOptions = {
     ~mapJsVariables: 'jsVariables => 'jsVariables,
     ~serializeVariables: 'variables => 'jsVariables,
   ) => Js_.t<'jsVariables> = (t, ~mapJsVariables, ~serializeVariables) => {
-    fetchPolicy: t.fetchPolicy->Belt.Option.map(FetchPolicy.toJs),
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(FetchPolicy.toJs),
     query: t.query,
     variables: t.variables->serializeVariables->mapJsVariables,
-    errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-    context: t.context,
+    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    context: ?t.context,
   }
 }
 
 module WatchQueryOptions = {
   module Js_ = {
     type t<'jsVariables> = {
-      fetchPolicy: option<WatchQueryFetchPolicy.Js_.t>,
-      nextFetchPolicy: option<WatchQueryFetchPolicy.Js_.t>,
+      fetchPolicy?: WatchQueryFetchPolicy.Js_.t,
+      nextFetchPolicy?: WatchQueryFetchPolicy.Js_.t,
       // ...extends QueryBaseOptions
       query: Graphql.documentNode,
       // We don't allow optional variables because it's not typesafe
       variables: 'jsVariables,
-      errorPolicy: option<ErrorPolicy.Js_.t>,
-      context: option<Js.Json.t>,
-      pollInterval: option<int>,
+      errorPolicy?: ErrorPolicy.Js_.t,
+      context?: Js.Json.t,
+      pollInterval?: int,
     }
   }
 
   type t<'jsVariables> = {
-    fetchPolicy: option<WatchQueryFetchPolicy.t>,
-    nextFetchPolicy: option<WatchQueryFetchPolicy.t>,
+    fetchPolicy?: WatchQueryFetchPolicy.t,
+    nextFetchPolicy?: WatchQueryFetchPolicy.t,
     query: Graphql.documentNode,
     variables: 'jsVariables,
-    errorPolicy: option<ErrorPolicy.t>,
-    context: option<Js.Json.t>,
-    pollInterval: option<int>,
+    errorPolicy?: ErrorPolicy.t,
+    context?: Js.Json.t,
+    pollInterval?: int,
   }
 
   let toJs: (
@@ -149,13 +149,13 @@ module WatchQueryOptions = {
     ~mapJsVariables: 'jsVariables => 'jsVariables,
     ~serializeVariables: 'variables => 'jsVariables,
   ) => Js_.t<'jsVariables> = (t, ~mapJsVariables, ~serializeVariables) => {
-    fetchPolicy: t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
-    nextFetchPolicy: t.nextFetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
+    nextFetchPolicy: ?t.nextFetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
     query: t.query,
     variables: t.variables->serializeVariables->mapJsVariables,
-    errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-    context: t.context,
-    pollInterval: t.pollInterval,
+    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    context: ?t.context,
+    pollInterval: ?t.pollInterval,
   }
 }
 
@@ -172,7 +172,7 @@ module UpdateQueryFn = {
     //     variables?: TSubscriptionVariables;
     // }) => TData;
     type t<'jsQueryData, 'subscriptionVariables, 'jsSubscriptionData> = (
-      . 'jsQueryData,
+      'jsQueryData,
       t_options<'jsSubscriptionData, 'subscriptionVariables>,
     ) => 'jsQueryData
   }
@@ -198,23 +198,24 @@ module UpdateQueryFn = {
     ~querySafeParse,
     ~querySerialize,
     ~subscriptionSafeParse,
+    jsQueryData,
+    {subscriptionData: {data}},
   ) =>
-    (. jsQueryData, {subscriptionData: {data}}) =>
-      switch (jsQueryData->querySafeParse, data->subscriptionSafeParse) {
-      | (Ok(queryData), Ok(subscriptionData)) =>
-        t(
-          queryData,
-          {
-            subscriptionData: {
-              data: subscriptionData,
-            },
+    switch (jsQueryData->querySafeParse, data->subscriptionSafeParse) {
+    | (Ok(queryData), Ok(subscriptionData)) =>
+      t(
+        queryData,
+        {
+          subscriptionData: {
+            data: subscriptionData,
           },
-        )->querySerialize
-      | (Error(parseError), _)
-      | (_, Error(parseError)) =>
-        onParseError(parseError)
-        jsQueryData
-      }
+        },
+      )->querySerialize
+    | (Error(parseError), _)
+    | (_, Error(parseError)) =>
+      onParseError(parseError)
+      jsQueryData
+    }
 }
 
 module SubscribeToMoreOptions = {
@@ -231,20 +232,18 @@ module SubscribeToMoreOptions = {
       document: Graphql.documentNode,
       // We don't allow optional variables because it's not typesafe
       variables: 'subscriptionVariables,
-      updateQuery: option<
-        UpdateQueryFn.Js_.t<'jsQueryData, 'subscriptionVariables, 'jsSubscriptionData>,
-      >,
-      onError: option<Js.Exn.t => unit>,
-      context: option<Js.Json.t>,
+      updateQuery?: UpdateQueryFn.Js_.t<'jsQueryData, 'subscriptionVariables, 'jsSubscriptionData>,
+      onError?: Js.Exn.t => unit,
+      context?: Js.Json.t,
     }
   }
 
   type t<'queryData, 'subscriptionVariables, 'subscriptionData> = {
     document: Graphql.documentNode,
     variables: 'subscriptionVariables,
-    updateQuery: option<UpdateQueryFn.t<'queryData, 'subscriptionVariables, 'subscriptionData>>,
-    onError: option<Js.Exn.t => unit>,
-    context: option<Js.Json.t>,
+    updateQuery?: UpdateQueryFn.t<'queryData, 'subscriptionVariables, 'subscriptionData>,
+    onError?: Js.Exn.t => unit,
+    context?: Js.Json.t,
   }
 
   let toJs: (
@@ -262,7 +261,7 @@ module SubscribeToMoreOptions = {
   ) => {
     document: t.document,
     variables: t.variables,
-    updateQuery: t.updateQuery->Belt.Option.map(
+    updateQuery: ?t.updateQuery->Belt.Option.map(
       UpdateQueryFn.toJs(
         ~onParseError=onUpdateQueryParseError,
         ~querySafeParse,
@@ -270,8 +269,8 @@ module SubscribeToMoreOptions = {
         ~subscriptionSafeParse,
       ),
     ),
-    onError: t.onError,
-    context: t.context,
+    onError: ?t.onError,
+    context: ?t.context,
   }
 }
 
@@ -288,18 +287,18 @@ module SubscriptionOptions = {
       query: Graphql.documentNode,
       // We don't allow optional variables because it's not typesafe
       variables: 'jsVariables,
-      fetchPolicy: option<FetchPolicy.Js_.t>,
-      errorPolicy: option<ErrorPolicy.Js_.t>,
-      context: option<Js.Json.t>,
+      fetchPolicy?: FetchPolicy.Js_.t,
+      errorPolicy?: ErrorPolicy.Js_.t,
+      context?: Js.Json.t,
     }
   }
 
   type t<'variables> = {
     query: Graphql.documentNode,
     variables: 'variables,
-    fetchPolicy: option<FetchPolicy.t>,
-    errorPolicy: option<ErrorPolicy.t>,
-    context: option<Js.Json.t>,
+    fetchPolicy?: FetchPolicy.t,
+    errorPolicy?: ErrorPolicy.t,
+    context?: Js.Json.t,
   }
 
   let toJs: (
@@ -309,15 +308,15 @@ module SubscriptionOptions = {
   ) => Js_.t<'jsVariables> = (t, ~mapJsVariables, ~serializeVariables) => {
     query: t.query,
     variables: t.variables->serializeVariables->mapJsVariables,
-    fetchPolicy: t.fetchPolicy->Belt.Option.map(FetchPolicy.toJs),
-    errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-    context: t.context,
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(FetchPolicy.toJs),
+    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    context: ?t.context,
   }
 }
 
 module MutationUpdaterFn = {
   module Js_ = {
-    type t<'jsData> = (. ApolloCache.t<Js.Json.t>, FetchResult.Js_.t<'jsData>) => unit // Non-Js_ cache is correct here
+    type t<'jsData> = (ApolloCache.t<Js.Json.t>, FetchResult.Js_.t<'jsData>) => unit // Non-Js_ cache is correct here
   }
 
   type t<'data> = (ApolloCache.t<Js.Json.t>, FetchResult.t<'data>) => unit
@@ -325,9 +324,9 @@ module MutationUpdaterFn = {
   let toJs: (t<'data>, ~safeParse: Types.safeParse<'data, 'jsData>) => Js_.t<'jsData> = (
     mutationUpdaterFn,
     ~safeParse,
-  ) =>
-    (. cache, jsFetchResult) =>
-      mutationUpdaterFn(cache, jsFetchResult->FetchResult.fromJs(~safeParse))
+    cache,
+    jsFetchResult,
+  ) => mutationUpdaterFn(cache, jsFetchResult->FetchResult.fromJs(~safeParse))
 }
 
 module RefetchQueryDescription = {
@@ -371,31 +370,31 @@ module MutationOptions = {
     // }
     type t<'jsData, 'jsVariables> = {
       mutation: Graphql.documentNode,
-      context: option<Js.Json.t>,
-      fetchPolicy: option<FetchPolicy__noCacheExtracted.Js_.t>,
+      context?: Js.Json.t,
+      fetchPolicy?: FetchPolicy__noCacheExtracted.Js_.t,
       // ...extends MutationBaseOption,
-      awaitRefetchQueries: option<bool>,
-      errorPolicy: option<ErrorPolicy.Js_.t>,
-      optimisticResponse: option<(. 'jsVariables) => 'jsData>,
-      update: option<MutationUpdaterFn.Js_.t<'jsData>>,
-      updateQueries: option<MutationQueryReducersMap.Js_.t<'jsData>>,
-      refetchQueries: option<RefetchQueryDescription.Js_.t>,
+      awaitRefetchQueries?: bool,
+      errorPolicy?: ErrorPolicy.Js_.t,
+      optimisticResponse?: 'jsVariables => 'jsData,
+      update?: MutationUpdaterFn.Js_.t<'jsData>,
+      updateQueries?: MutationQueryReducersMap.Js_.t<'jsData>,
+      refetchQueries?: RefetchQueryDescription.Js_.t,
       // We don't allow optional variables because it's not typesafe
       variables: 'jsVariables,
     }
   }
 
   type t<'data, 'variables, 'jsVariables> = {
-    context: option<Js.Json.t>,
-    fetchPolicy: option<FetchPolicy__noCacheExtracted.t>,
+    context?: Js.Json.t,
+    fetchPolicy?: FetchPolicy__noCacheExtracted.t,
     mutation: Graphql.documentNode,
     // ...extends MutationBaseOptions,
-    awaitRefetchQueries: option<bool>,
-    errorPolicy: option<ErrorPolicy.t>,
-    optimisticResponse: option<'jsVariables => 'data>,
-    refetchQueries: option<RefetchQueryDescription.t>,
-    update: option<MutationUpdaterFn.t<'data>>,
-    updateQueries: option<MutationQueryReducersMap.t<'data>>,
+    awaitRefetchQueries?: bool,
+    errorPolicy?: ErrorPolicy.t,
+    optimisticResponse?: 'jsVariables => 'data,
+    refetchQueries?: RefetchQueryDescription.t,
+    update?: MutationUpdaterFn.t<'data>,
+    updateQueries?: MutationQueryReducersMap.t<'data>,
     variables: 'variables,
   }
 
@@ -412,17 +411,17 @@ module MutationOptions = {
     ~serialize,
     ~serializeVariables,
   ) => {
-    awaitRefetchQueries: t.awaitRefetchQueries,
-    context: t.context,
-    errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-    fetchPolicy: t.fetchPolicy->Belt.Option.map(FetchPolicy__noCacheExtracted.toJs),
+    awaitRefetchQueries: ?t.awaitRefetchQueries,
+    context: ?t.context,
+    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(FetchPolicy__noCacheExtracted.toJs),
     mutation: t.mutation,
-    optimisticResponse: t.optimisticResponse->Belt.Option.map(optimisticResponse =>
-      (. variables) => optimisticResponse(variables)->serialize
+    optimisticResponse: ?t.optimisticResponse->Belt.Option.map((optimisticResponse, variables) =>
+      optimisticResponse(variables)->serialize
     ),
-    refetchQueries: t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
-    update: t.update->Belt.Option.map(MutationUpdaterFn.toJs(~safeParse)),
-    updateQueries: t.updateQueries->Belt.Option.map(MutationQueryReducersMap.toJs(~safeParse)),
+    refetchQueries: ?t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
+    update: ?t.update->Belt.Option.map(MutationUpdaterFn.toJs(~safeParse)),
+    updateQueries: ?t.updateQueries->Belt.Option.map(MutationQueryReducersMap.toJs(~safeParse)),
     variables: t.variables->serializeVariables->mapJsVariables,
   }
 }

--- a/src/@apollo/client/errors/ApolloClient__Errors_ApolloError.res
+++ b/src/@apollo/client/errors/ApolloClient__Errors_ApolloError.res
@@ -108,7 +108,7 @@ module Js_ = {
             } else if (error && typeof error.message === "string" && error.extensions) {
               return makeApolloError({graphQLErrors: [error]});
             } else {
-              return makeApolloError({networkError: ensureError(error)}) 
+              return makeApolloError({networkError: ensureError(error)})
             }
           }
         `)(error, make, ensureError)

--- a/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.res
+++ b/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.res
@@ -16,10 +16,10 @@ module GraphQLRequest = {
     // }
     type t = {
       query: Graphql.documentNode,
-      variables: option<Js.Json.t>,
-      operationName: option<string>,
-      context: option<Js.Json.t>,
-      extensions: option<Js.Json.t>,
+      variables?: Js.Json.t,
+      operationName?: string,
+      context?: Js.Json.t,
+      extensions?: Js.Json.t,
     }
   }
 
@@ -169,7 +169,7 @@ module RequestHandler = {
   module Js_ = {
     // export declare type RequestHandler = (operation: Operation, forward: NextLink) => Observable<FetchResult> | null;
     type t = (
-      . Operation.Js_.t,
+      Operation.Js_.t,
       NextLink.Js_.t,
     ) => Js.Null.t<Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>>
   }
@@ -180,5 +180,5 @@ module RequestHandler = {
     NextLink.Js_.t,
   ) => option<Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>>
 
-  let toJs: t => Js_.t = t => (. operation, forward) => t(operation, forward)->Js.Null.fromOption
+  let toJs: t => Js_.t = (t, operation, forward) => t(operation, forward)->Js.Null.fromOption
 }

--- a/src/@apollo/client/link/http/ApolloClient__Link_Http_HttpLink.res
+++ b/src/@apollo/client/link/http/ApolloClient__Link_Http_HttpLink.res
@@ -32,11 +32,11 @@ let make: (
   (),
 ) =>
   Js_.make({
-    uri,
-    includeExtensions,
-    fetch,
-    headers,
-    credentials,
-    fetchOptions,
-    useGETForQueries,
+    ?uri,
+    ?includeExtensions,
+    ?fetch,
+    ?headers,
+    ?credentials,
+    ?fetchOptions,
+    ?useGETForQueries,
   })

--- a/src/@apollo/client/link/http/ApolloClient__Link_Http_SelectHttpOptionsAndBody.res
+++ b/src/@apollo/client/link/http/ApolloClient__Link_Http_SelectHttpOptionsAndBody.res
@@ -30,13 +30,13 @@ module HttpOptions = {
     type t_fetch
 
     type t = {
-      uri: option<UriFunction.Js_.t>,
-      includeExtensions: option<bool>,
-      fetch: option<t_fetch>,
-      headers: option<Js.Json.t>,
-      credentials: option<string>,
-      fetchOptions: option<Js.Json.t>,
-      useGETForQueries: option<bool>,
+      uri?: UriFunction.Js_.t,
+      includeExtensions?: bool,
+      fetch?: t_fetch,
+      headers?: Js.Json.t,
+      credentials?: string,
+      fetchOptions?: Js.Json.t,
+      useGETForQueries?: bool,
     }
   }
 

--- a/src/@apollo/client/link/retry/ApolloClient__Link_Retry_DelayFunction.res
+++ b/src/@apollo/client/link/retry/ApolloClient__Link_Retry_DelayFunction.res
@@ -21,9 +21,9 @@ module DelayFunctionOptions = {
   //     jitter?: boolean;
   // }
   type t = {
-    initial: option<int>,
-    max: option<int>,
-    jitter: option<int>,
+    initial?: int,
+    max?: int,
+    jitter?: int,
   }
 
   module Js_ = {

--- a/src/@apollo/client/link/retry/ApolloClient__Link_Retry_RetryFunction.res
+++ b/src/@apollo/client/link/retry/ApolloClient__Link_Retry_RetryFunction.res
@@ -21,18 +21,18 @@ module RetryFunctionOptions = {
     //     retryIf?: (error: any, operation: Operation) => boolean | Promise<boolean>;
     // }
     type t = {
-      max: option<int>,
+      max?: int,
       retryIf: (option<Js.Json.t>, Operation.Js_.t) => Js.Promise.t<bool>,
     }
   }
 
   type t = {
-    max: option<int>,
+    max?: int,
     retryIf: (~error: option<Js.Json.t>, ~operation: Operation.t) => Js.Promise.t<bool>,
   }
 
   let toJs: t => Js_.t = t => {
-    max: t.max,
+    max: ?t.max,
     retryIf: (error, operation) => t.retryIf(~error, ~operation=operation->Operation.fromJs),
   }
 }

--- a/src/@apollo/client/link/retry/ApolloClient__Link_Retry_RetryLink.res
+++ b/src/@apollo/client/link/retry/ApolloClient__Link_Retry_RetryLink.res
@@ -35,8 +35,8 @@ module Options = {
     //     }
     // }
     type t = {
-      delay: option<T_delayUnion.t>,
-      attempts: option<T_attemptsUnion.t>,
+      delay?: T_delayUnion.t,
+      attempts?: T_attemptsUnion.t,
     }
   }
 
@@ -44,12 +44,12 @@ module Options = {
   type t_attempts = RetryFunctionOptions(RetryFunctionOptions.t) | RetryFunction(RetryFunction.t)
 
   type t = {
-    delay: option<t_delay>,
-    attempts: option<t_attempts>,
+    delay?: t_delay,
+    attempts?: t_attempts,
   }
 
   let toJs: t => Js_.t = t => {
-    delay: t.delay->Belt.Option.map(delay =>
+    delay: ?t.delay->Belt.Option.map(delay =>
       switch delay {
       | DelayFunctionOptions(delayFunctionOptions) =>
         Js_.T_delayUnion.delayFunctionOptions(delayFunctionOptions)
@@ -57,7 +57,7 @@ module Options = {
         Js_.T_delayUnion.delayFunction(delayFunction->DelayFunction.toJs)
       }
     ),
-    attempts: t.attempts->Belt.Option.map(attempts =>
+    attempts: ?t.attempts->Belt.Option.map(attempts =>
       switch attempts {
       | RetryFunctionOptions(retryFunctionOptions) =>
         Js_.T_attemptsUnion.retryFunctionOptions(retryFunctionOptions->RetryFunctionOptions.toJs)
@@ -82,7 +82,7 @@ module Js_ = {
 let make = (~attempts=?, ~delay=?, ()) =>
   Js_.make(
     Options.toJs({
-      attempts,
-      delay,
+      ?attempts,
+      ?delay,
     }),
   )

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.res
@@ -16,7 +16,7 @@ module Js_ = {
   // export declare function useLazyQuery<TData = any, TVariables = OperationVariables>(query: DocumentNode, options?: LazyQueryHookOptions<TData, TVariables>): QueryTuple<TData, TVariables>;
   @module("@apollo/client")
   external useLazyQuery: (
-    . Graphql.documentNode,
+    Graphql.documentNode,
     LazyQueryHookOptions.Js_.t<'jsData, 'jsVariables>,
   ) => QueryTuple.Js_.t<'jsData, 'jsVariables> = "useLazyQuery"
 }
@@ -60,24 +60,22 @@ let useLazyQuery:
     (),
   ) => {
     let safeParse = Utils.safeParse(Operation.parse)
-    let jsQueryTuple = Js_.useLazyQuery(.
+    let jsQueryTuple = Js_.useLazyQuery(
       Operation.query,
       LazyQueryHookOptions.toJs(
         {
-          client,
-          context,
-          displayName,
-          errorPolicy,
-          fetchPolicy,
-          nextFetchPolicy,
-          onCompleted,
-          onError,
-          notifyOnNetworkStatusChange,
-          partialRefetch,
-          pollInterval,
-          query: None,
-          ssr,
-          variables: None,
+          ?client,
+          ?context,
+          ?displayName,
+          ?errorPolicy,
+          ?fetchPolicy,
+          ?nextFetchPolicy,
+          ?onCompleted,
+          ?onError,
+          ?notifyOnNetworkStatusChange,
+          ?partialRefetch,
+          ?pollInterval,
+          ?ssr,
         },
         ~safeParse,
         ~serializeVariables=Operation.serializeVariables,
@@ -137,24 +135,23 @@ let useLazyQueryWithVariables:
   ) => {
     let safeParse = Utils.safeParse(Operation.parse)
 
-    let jsQueryTuple = Js_.useLazyQuery(.
+    let jsQueryTuple = Js_.useLazyQuery(
       Operation.query,
       LazyQueryHookOptions.toJs(
         {
-          client,
-          context,
-          displayName,
-          errorPolicy,
-          fetchPolicy,
-          nextFetchPolicy,
-          onCompleted,
-          onError,
-          notifyOnNetworkStatusChange,
-          partialRefetch,
-          pollInterval,
-          query: None,
-          ssr,
-          variables: Some(variables),
+          ?client,
+          ?context,
+          ?displayName,
+          ?errorPolicy,
+          ?fetchPolicy,
+          ?nextFetchPolicy,
+          ?onCompleted,
+          ?onError,
+          ?notifyOnNetworkStatusChange,
+          ?partialRefetch,
+          ?pollInterval,
+          ?ssr,
+          variables,
         },
         ~safeParse,
         ~serializeVariables=Operation.serializeVariables,

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseMutation.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseMutation.res
@@ -19,7 +19,7 @@ module Js_ = {
   // export declare function useMutation<TData = any, TVariables = OperationVariables>(mutation: DocumentNode, options?: MutationHookOptions<TData, TVariables>): MutationTuple<TData, TVariables>;
   @module("@apollo/client")
   external useMutation: (
-    . Graphql.documentNode,
+    Graphql.documentNode,
     MutationHookOptions.Js_.t<'jsData, 'jsVariables>,
   ) => MutationTuple.Js_.t<'jsData, 'jsVariables> = "useMutation"
 }
@@ -63,7 +63,7 @@ let useMutation:
   ) => {
     let safeParse = Utils.safeParse(Operation.parse)
 
-    let jsMutationTuple = Js_.useMutation(.
+    let jsMutationTuple = Js_.useMutation(
       Operation.query,
       MutationHookOptions.toJs(
         {
@@ -141,7 +141,7 @@ let useMutationWithVariables:
   ) => {
     let safeParse = Utils.safeParse(Operation.parse)
 
-    let jsMutationTuple = Js_.useMutation(.
+    let jsMutationTuple = Js_.useMutation(
       Operation.query,
       MutationHookOptions.toJs(
         {

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.res
@@ -16,7 +16,7 @@ module Js_ = {
   // export declare function useQuery<TData = any, TVariables = OperationVariables>(query: DocumentNode, options?: QueryHookOptions<TData, TVariables>): QueryResult<TData, TVariables>;
   @module("@apollo/client")
   external useQuery: (
-    . Graphql.documentNode,
+    Graphql.documentNode,
     QueryHookOptions.Js_.t<'jsData, 'jsVariables>,
   ) => QueryResult.Js_.t<'jsData, 'jsVariables> = "useQuery"
 }
@@ -65,24 +65,23 @@ let useQuery:
   ) => {
     let safeParse = Utils.safeParse(Operation.parse)
 
-    let jsQueryResult = Js_.useQuery(.
+    let jsQueryResult = Js_.useQuery(
       Operation.query,
       QueryHookOptions.toJs(
         {
-          client,
-          context,
-          displayName,
-          errorPolicy,
-          fetchPolicy,
-          nextFetchPolicy,
-          onCompleted,
-          onError,
-          notifyOnNetworkStatusChange,
-          partialRefetch,
-          pollInterval,
-          query: None,
-          skip,
-          ssr,
+          ?client,
+          ?context,
+          ?displayName,
+          ?errorPolicy,
+          ?fetchPolicy,
+          ?nextFetchPolicy,
+          ?onCompleted,
+          ?onError,
+          ?notifyOnNetworkStatusChange,
+          ?partialRefetch,
+          ?pollInterval,
+          ?skip,
+          ?ssr,
           variables,
         },
         ~mapJsVariables,
@@ -117,7 +116,7 @@ module Extend = (M: Operation) => {
     RefetchQueryDescription.PureQueryOptions({
       query: M.query,
       variables: jsVariables,
-      context,
+      ?context,
     })
   }
 

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.res
@@ -27,7 +27,7 @@ module Js_ = {
   // };
   @module("@apollo/client")
   external useSubscription: (
-    . Graphql.Language.documentNode,
+    Graphql.Language.documentNode,
     SubscriptionHookOptions.Js_.t<'jsData, 'jsVariables>,
   ) => useSubscription_result<'jsData, 'jsVariables> = "useSubscription"
 }
@@ -68,17 +68,16 @@ let useSubscription:
   ) => {
     let safeParse = Utils.safeParse(Operation.parse)
 
-    let jsSubscriptionResult = Js_.useSubscription(.
+    let jsSubscriptionResult = Js_.useSubscription(
       Operation.query,
       SubscriptionHookOptions.toJs(
         {
-          client,
-          fetchPolicy,
-          onSubscriptionData,
-          onSubscriptionComplete,
-          subscription: None,
-          shouldResubscribe,
-          skip,
+          ?client,
+          ?fetchPolicy,
+          ?onSubscriptionData,
+          ?onSubscriptionComplete,
+          ?shouldResubscribe,
+          ?skip,
           variables,
         },
         ~mapJsVariables,

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.res
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.res
@@ -22,54 +22,49 @@ module QueryHookOptions = {
     // export interface QueryHookOptions<TData = any, TVariables = OperationVariables> extends QueryFunctionOptions<TData, TVariables> {
     //     query?: DocumentNode;
     // }
-    type t<'jsData, 'jsVariables>
-
-    // NOTE: We are using @obj here because passing properties that are defined with a value of undefined has effects
-    @obj
-    external make: (
-      ~query: Graphql.documentNode=?,
+    type t<'jsData, 'jsVariables> = {
+      query?: Graphql.documentNode,
       // ...extends QueryFunctionOptions
-      ~displayName: string=?,
-      ~skip: bool=?,
-      ~onCompleted: 'jsData => unit=?,
-      ~onError: (. ApolloError.Js_.t) => unit=?,
+      displayName?: string,
+      skip?: bool,
+      onCompleted?: 'jsData => unit,
+      onError?: ApolloError.Js_.t => unit,
       // ..extends BaseQueryOptions
-      ~client: ApolloClient.t=?,
-      ~context: Js.Json.t=?, // ACTUAL: Record<string, any=?>
-      ~errorPolicy: string=?,
-      ~fetchPolicy: string=?,
-      ~nextFetchPolicy: string=?,
-      ~notifyOnNetworkStatusChange: bool=?,
-      ~partialRefetch: bool=?,
-      ~pollInterval: int=?,
+      client?: ApolloClient.t,
+      context?: Js.Json.t, // ACTUAL: Record<string, any>
+      errorPolicy?: ErrorPolicy.Js_.t,
+      fetchPolicy?: WatchQueryFetchPolicy.Js_.t,
+      nextFetchPolicy?: WatchQueryFetchPolicy.Js_.t,
+      notifyOnNetworkStatusChange?: bool,
+      partialRefetch?: bool,
+      pollInterval?: int,
       // INTENTIONALLY IGNORED (but now with safeParse and result unwrapping, maybe it shouldn't be?)
-      // ~returnPartialData: bool=?,
-      ~ssr: bool=?,
+      // returnPartialData?: bool,
+      ssr?: bool,
       // We don't allow optional variables because it's not typesafe
-      ~variables: 'jsVariables,
-      unit,
-    ) => t<'jsData, 'jsVariables> = ""
+      variables: 'jsVariables,
+    }
   }
 
   type t<'data, 'variables> = {
-    query: option<Graphql.documentNode>,
+    query?: Graphql.documentNode,
     // ...extends QueryFunctionOptions
-    displayName: option<string>,
-    skip: option<bool>,
-    onCompleted: option<Types.parseResult<'data> => unit>,
-    onError: option<ApolloError.t => unit>,
+    displayName?: string,
+    skip?: bool,
+    onCompleted?: Types.parseResult<'data> => unit,
+    onError?: ApolloError.t => unit,
     // ...extends BaseQueryOptions
-    client: option<ApolloClient.t>,
-    context: option<Js.Json.t>,
-    errorPolicy: option<ErrorPolicy.t>,
-    fetchPolicy: option<WatchQueryFetchPolicy.t>,
-    nextFetchPolicy: option<WatchQueryFetchPolicy.t>,
-    notifyOnNetworkStatusChange: option<bool>,
-    partialRefetch: option<bool>,
-    pollInterval: option<int>,
+    client?: ApolloClient.t,
+    context?: Js.Json.t,
+    errorPolicy?: ErrorPolicy.t,
+    fetchPolicy?: WatchQueryFetchPolicy.t,
+    nextFetchPolicy?: WatchQueryFetchPolicy.t,
+    notifyOnNetworkStatusChange?: bool,
+    partialRefetch?: bool,
+    pollInterval?: int,
     // INTENTIONALLY IGNORED (but now with safeParse and result unwrapping, maybe it shouldn't be?)
-    // returnPartialData: option(bool),
-    ssr: option<bool>,
+    // returnPartialData?: bool,
+    ssr?: bool,
     variables: 'variables,
   }
 
@@ -78,29 +73,27 @@ module QueryHookOptions = {
     ~mapJsVariables: 'jsVariables => 'jsVariables,
     ~safeParse: Types.safeParse<'data, 'jsData>,
     ~serializeVariables: 'variables => 'jsVariables,
-  ): Js_.t<'jsData, 'jsVariables> =>
-    Js_.make(
-      ~client=?t.client,
-      ~context=?t.context,
-      ~displayName=?t.displayName,
-      ~errorPolicy=?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-      ~onCompleted=?t.onCompleted->Belt.Option.map((onCompleted, jsData) =>
-        onCompleted(jsData->safeParse)
-      ),
-      ~onError=?t.onError->Belt.Option.map(onError =>
-        (. jsApolloError) => onError(ApolloError.fromJs(jsApolloError))
-      ),
-      ~fetchPolicy=?t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
-      ~nextFetchPolicy=?t.nextFetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
-      ~notifyOnNetworkStatusChange=?t.notifyOnNetworkStatusChange,
-      ~query=?t.query,
-      ~pollInterval=?t.pollInterval,
-      ~partialRefetch=?t.partialRefetch,
-      ~skip=?t.skip,
-      ~ssr=?t.ssr,
-      ~variables=t.variables->serializeVariables->mapJsVariables,
-      (),
-    )
+  ): Js_.t<'jsData, 'jsVariables> => {
+    client: ?t.client,
+    context: ?t.context,
+    displayName: ?t.displayName,
+    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    onCompleted: ?t.onCompleted->Belt.Option.map((onCompleted, jsData) =>
+      jsData->safeParse->onCompleted
+    ),
+    onError: ?t.onError->Belt.Option.map((onError, jsApolloError) =>
+      onError(ApolloError.fromJs(jsApolloError))
+    ),
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
+    nextFetchPolicy: ?t.nextFetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
+    notifyOnNetworkStatusChange: ?t.notifyOnNetworkStatusChange,
+    query: ?t.query,
+    pollInterval: ?t.pollInterval,
+    partialRefetch: ?t.partialRefetch,
+    skip: ?t.skip,
+    ssr: ?t.ssr,
+    variables: t.variables->serializeVariables->mapJsVariables,
+  }
 }
 
 module LazyQueryHookOptions = {
@@ -109,80 +102,77 @@ module LazyQueryHookOptions = {
     //     query?: DocumentNode;
     // }
 
-    type t<'jsData, 'jsVariables>
-
-    // NOTE: We are using @obj here because passing properties that are defined with a value of undefined has effects
-    @obj
-    external make: (
-      ~query: Graphql.documentNode=?,
+    type t<'jsData, 'jsVariables> = {
+      query?: Graphql.documentNode,
       // ...extends QueryFunctionOptions
-      ~displayName: string=?,
-      ~onCompleted: 'jsData => unit=?,
-      ~onError: (. ApolloError.Js_.t) => unit=?,
+      displayName?: string,
+      onCompleted?: 'jsData => unit,
+      onError?: ApolloError.Js_.t => unit,
       // ..extends BaseQueryOptions
-      ~client: ApolloClient.t=?,
-      ~context: Js.Json.t=?, // ACTUAL: Record<string, any>,
-      ~errorPolicy: string=?,
-      ~fetchPolicy: string=?,
-      ~nextFetchPolicy: string=?,
-      ~notifyOnNetworkStatusChange: bool=?,
-      ~partialRefetch: bool=?,
-      ~pollInterval: int=?,
+      client?: ApolloClient.t,
+      context?: Js.Json.t, // ACTUAL: Record<string, any>,
+      errorPolicy?: ErrorPolicy.Js_.t,
+      fetchPolicy?: WatchQueryFetchPolicy.Js_.t,
+      nextFetchPolicy?: WatchQueryFetchPolicy.Js_.t,
+      notifyOnNetworkStatusChange?: bool,
+      partialRefetch?: bool,
+      pollInterval?: int,
       // INTENTIONALLY IGNORED (but now with safeParse and result unwrapping, maybe it shouldn't be?)
-      // ~returnPartialData:bool=?,
-      ~ssr: bool=?,
-      ~variables: 'jsVariables=?,
-      unit,
-    ) => t<'jsData, 'jsVariables> = ""
+      // returnPartialData?: bool,
+      ssr?: bool,
+      variables?: 'jsVariables,
+    }
   }
 
   type t<'data, 'variables> = {
-    query: option<Graphql.documentNode>,
+    query?: Graphql.documentNode,
     // ...extends QueryFunctionOptions
-    displayName: option<string>,
-    onCompleted: option<Types.parseResult<'data> => unit>,
-    onError: option<ApolloError.t => unit>,
+    displayName?: string,
+    onCompleted?: Types.parseResult<'data> => unit,
+    onError?: ApolloError.t => unit,
     // ...extends BaseQueryOptions
-    client: option<ApolloClient.t>,
-    context: option<Js.Json.t>,
-    errorPolicy: option<ErrorPolicy.t>,
-    fetchPolicy: option<WatchQueryFetchPolicy.t>,
-    nextFetchPolicy: option<WatchQueryFetchPolicy.t>,
-    notifyOnNetworkStatusChange: option<bool>,
-    partialRefetch: option<bool>,
-    pollInterval: option<int>,
+    client?: ApolloClient.t,
+    context?: Js.Json.t,
+    errorPolicy?: ErrorPolicy.t,
+    fetchPolicy?: WatchQueryFetchPolicy.t,
+    nextFetchPolicy?: WatchQueryFetchPolicy.t,
+    notifyOnNetworkStatusChange?: bool,
+    partialRefetch?: bool,
+    pollInterval?: int,
     // INTENTIONALLY IGNORED (but now with safeParse and result unwrapping, maybe it shouldn't be?)
-    // returnPartialData: option(bool),
-    ssr: option<bool>,
-    variables: option<'variables>,
+    // returnPartialData?: bool,
+    ssr?: bool,
+    variables?: 'variables,
   }
 
   let toJs = (
     t: t<'data, 'variables>,
     ~safeParse: Types.safeParse<'data, 'jsData>,
     ~serializeVariables: 'variables => 'jsVariables,
-  ): Js_.t<'jsData, 'jsVariables> =>
-    Js_.make(
-      ~client=?t.client,
-      ~context=?t.context,
-      ~displayName=?t.displayName,
-      ~errorPolicy=?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-      ~onCompleted=?t.onCompleted->Belt.Option.map((onCompleted, jsData) =>
-        onCompleted(jsData->safeParse)
-      ),
-      ~onError=?t.onError->Belt.Option.map(onError =>
-        (. jsApolloError) => onError(ApolloError.fromJs(jsApolloError))
-      ),
-      ~fetchPolicy=?t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
-      ~notifyOnNetworkStatusChange=?t.notifyOnNetworkStatusChange,
-      ~query=?t.query,
-      ~pollInterval=?t.pollInterval,
-      ~partialRefetch=?t.partialRefetch,
-      ~ssr=?t.ssr,
-      ~variables=?t.variables->Belt.Option.map(serializeVariables),
-      (),
-    )
+  ): Js_.t<'jsData, 'jsVariables> => {
+    client: ?t.client,
+    context: ?t.context,
+    displayName: ?t.displayName,
+    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    onCompleted: ?t.onCompleted->Belt.Option.map((onCompleted, jsData) =>
+      onCompleted(jsData->safeParse)
+    ),
+    onError: ?t.onError->Belt.Option.map((onError, jsApolloError) =>
+      onError(ApolloError.fromJs(jsApolloError))
+    ),
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
+    notifyOnNetworkStatusChange: ?t.notifyOnNetworkStatusChange,
+    query: ?t.query,
+    pollInterval: ?t.pollInterval,
+    partialRefetch: ?t.partialRefetch,
+    ssr: ?t.ssr,
+    variables: ?switch t.variables {
+    | Some(variables) => serializeVariables(variables)->Some
+    | None => None
+    },
+  }
 }
+
 module QueryLazyOptions = {
   module Js_ = {
     // export interface QueryLazyOptions<TVariables> {
@@ -191,7 +181,7 @@ module QueryLazyOptions = {
     // }
     type t<'jsVariables> = {
       variables: 'jsVariables,
-      context: option<Js.Json.t>,
+      context?: Js.Json.t,
     }
   }
 
@@ -204,24 +194,18 @@ module QueryResult = {
 
   module Js_ = {
     type t_fetchMoreOptions_updateQueryOptions<'jsData, 'jsVariables> = {
-      fetchMoreResult: option<'jsData>,
-      variables: option<'jsVariables>,
+      fetchMoreResult?: 'jsData,
+      variables?: 'jsVariables,
     }
 
-    // We use abstract because Apollo is looking at query key, not just value
-    @deriving(abstract)
     type t_fetchMoreOptions<'jsData, 'jsVariables> = {
-      @optional
-      query: Graphql.Language.documentNode,
+      query?: Graphql.Language.documentNode,
       // ...extends FetchMoreQueryOptions
-      @optional
-      variables: 'jsVariables,
-      @optional
-      context: Js.Json.t,
+      variables?: 'jsVariables,
+      context?: Js.Json.t,
       // ...extends FetchMoreOptions
-      @optional
-      updateQuery: (
-        . 'jsData,
+      updateQuery?: (
+        'jsData,
         t_fetchMoreOptions_updateQueryOptions<'jsData, 'jsVariables>,
       ) => 'jsData,
     }
@@ -381,44 +365,41 @@ module QueryResult = {
       let parseErrorDuringCall: ref<option<Types.parseResult<_>>> = ref(None)
 
       js
-      ->Js_.fetchMore(
-        Js_.t_fetchMoreOptions(
-          ~context?,
-          ~updateQuery=?updateQuery->Belt.Option.map(updateQuery =>
-            (.
+      ->Js_.fetchMore({
+        ?context,
+        updateQuery: ?updateQuery->Belt.Option.map((
+          updateQuery,
+          previousResult,
+          jsFetchMoreOptions: Js_.t_fetchMoreOptions_updateQueryOptions<'jsData, 'jsVariables>,
+        ) =>
+          switch (
+            safeParse(previousResult),
+            jsFetchMoreOptions.fetchMoreResult->Belt.Option.map(safeParse),
+          ) {
+          | (Ok(previousResult), Some(Ok(fetchMoreResult))) =>
+            updateQuery(
               previousResult,
-              jsFetchMoreOptions: Js_.t_fetchMoreOptions_updateQueryOptions<'jsData, 'jsVariables>,
-            ) =>
-              switch (
-                safeParse(previousResult),
-                jsFetchMoreOptions.fetchMoreResult->Belt.Option.map(safeParse),
-              ) {
-              | (Ok(previousResult), Some(Ok(fetchMoreResult))) =>
-                updateQuery(
-                  previousResult,
-                  {
-                    fetchMoreResult: Some(fetchMoreResult),
-                    variables: jsFetchMoreOptions.variables,
-                  },
-                )->serialize
-              | (Ok(previousResult), None) =>
-                updateQuery(
-                  previousResult,
-                  {
-                    fetchMoreResult: None,
-                    variables: jsFetchMoreOptions.variables,
-                  },
-                )->serialize
-              | (Error(parseError), _)
-              | (Ok(_), Some(Error(parseError))) =>
-                parseErrorDuringCall.contents = Some(Error(parseError))
-                previousResult
-              }
-          ),
-          ~variables=?variables->Belt.Option.map(v => v->serializeVariables->mapJsVariables),
-          (),
+              {
+                fetchMoreResult: Some(fetchMoreResult),
+                variables: jsFetchMoreOptions.variables,
+              },
+            )->serialize
+          | (Ok(previousResult), None) =>
+            updateQuery(
+              previousResult,
+              {
+                fetchMoreResult: None,
+                variables: jsFetchMoreOptions.variables,
+              },
+            )->serialize
+          | (Error(parseError), _)
+          | (Ok(_), Some(Error(parseError))) =>
+            parseErrorDuringCall.contents = Some(Error(parseError))
+            previousResult
+          }
         ),
-      )
+        variables: ?variables->Belt.Option.map(v => v->serializeVariables->mapJsVariables),
+      })
       ->Js.Promise.then_(jsApolloQueryResult =>
         Js.Promise.resolve(
           switch parseErrorDuringCall.contents {
@@ -484,11 +465,11 @@ module QueryResult = {
           {
             document: Operation.query,
             variables,
-            updateQuery,
-            onError: onError->Belt.Option.map((onError, error) =>
+            ?updateQuery,
+            onError: ?onError->Belt.Option.map((onError, error) =>
               onError(SubscriptionError(error))
             ),
-            context,
+            ?context,
           },
           ~onUpdateQueryParseError=parseError =>
             switch onError {
@@ -635,16 +616,15 @@ module QueryTuple = {
     ~serializeVariables,
   ) => (
     (~context=?, ~mapJsVariables=ApolloClient__Utils.identity, variables) =>
-      jsExecuteQuery({
-        context,
-        variables: variables->serializeVariables->mapJsVariables,
-      }) |> Js.Promise.then_(jsResult =>
-        QueryResult.fromJs(
-          jsResult,
-          ~safeParse,
-          ~serialize,
-          ~serializeVariables,
-        ) |> Js.Promise.resolve
+      Js.Promise.then_(
+        jsResult =>
+          Js.Promise.resolve(
+            QueryResult.fromJs(jsResult, ~safeParse, ~serialize, ~serializeVariables),
+          ),
+        jsExecuteQuery({
+          ?context,
+          variables: variables->serializeVariables->mapJsVariables,
+        }),
       ),
     jsLazyQueryResult->LazyQueryResult.fromJs(~safeParse, ~serialize, ~serializeVariables),
   )
@@ -679,16 +659,15 @@ module QueryTuple__noVariables = {
     ~variables,
   ) => (
     (~context=?, ()) =>
-      jsExecuteQuery({
-        context,
-        variables: variables->serializeVariables->mapJsVariables,
-      }) |> Js.Promise.then_(jsResult =>
-        QueryResult.fromJs(
-          jsResult,
-          ~safeParse,
-          ~serialize,
-          ~serializeVariables,
-        ) |> Js.Promise.resolve
+      Js.Promise.then_(
+        jsResult =>
+          Js.Promise.resolve(
+            QueryResult.fromJs(jsResult, ~safeParse, ~serialize, ~serializeVariables),
+          ),
+        jsExecuteQuery({
+          ?context,
+          variables: variables->serializeVariables->mapJsVariables,
+        }),
       ),
     jsLazyQueryResult->LazyQueryResult.fromJs(~safeParse, ~serialize, ~serializeVariables),
   )
@@ -750,28 +729,23 @@ module MutationHookOptions = {
     // export interface MutationHookOptions<TData = any, TVariables = OperationVariables> extends BaseMutationOptions<TData, TVariables> {
     //   mutation?: DocumentNode;
     // }
-    type t<'jsData, 'jsVariables>
-
-    // NOTE: We are using @obj here because passing properties that are defined with a value of undefined has effects
-    @obj
-    external make: (
-      ~mutation: Graphql.documentNode=?,
+    type t<'jsData, 'jsVariables> = {
+      mutation?: Graphql.documentNode,
       // ...extends BaseMutationOptions
-      ~awaitRefetchQueries: bool=?,
-      ~client: ApolloClient.t=?, // Non-Js_ client is appropriate here
-      ~context: Js.Json.t=?, // actual: option(Context)
-      ~errorPolicy: ErrorPolicy.Js_.t=?,
-      ~fetchPolicy: FetchPolicy__noCacheExtracted.Js_.t=?,
-      ~ignoreResults: bool=?,
-      ~notifyOnNetworkStatusChange: bool=?,
-      ~onError: (. ApolloError.Js_.t) => unit=?,
-      ~onCompleted: 'jsData => unit=?,
-      ~optimisticResponse: 'jsVariables => 'jsData=?,
-      ~refetchQueries: RefetchQueryDescription.Js_.t=?,
-      ~update: MutationUpdaterFn.Js_.t<'jsData>=?,
-      ~variables: 'jsVariables=?,
-      unit,
-    ) => t<'jsData, 'jsVariables> = ""
+      awaitRefetchQueries?: bool,
+      client?: ApolloClient.t, // Non-Js_ client is appropriate here
+      context?: Js.Json.t, // actual: option(Context)
+      errorPolicy?: ErrorPolicy.Js_.t,
+      fetchPolicy?: FetchPolicy__noCacheExtracted.Js_.t,
+      ignoreResults?: bool,
+      notifyOnNetworkStatusChange?: bool,
+      onError?: ApolloError.Js_.t => unit,
+      onCompleted?: 'jsData => unit,
+      optimisticResponse?: 'jsVariables => 'jsData,
+      refetchQueries?: RefetchQueryDescription.Js_.t,
+      update?: MutationUpdaterFn.Js_.t<'jsData>,
+      variables?: 'jsVariables,
+    }
   }
 
   type t<'data, 'variables, 'jsVariables> = {
@@ -803,30 +777,28 @@ module MutationHookOptions = {
     ~safeParse,
     ~serialize,
     ~serializeVariables,
-  ) =>
-    Js_.make(
-      ~awaitRefetchQueries=?t.awaitRefetchQueries,
-      ~context=?t.context,
-      ~client=?t.client,
-      ~errorPolicy=?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-      ~fetchPolicy=?t.fetchPolicy->Belt.Option.map(FetchPolicy__noCacheExtracted.toJs),
-      ~ignoreResults=?t.ignoreResults,
-      ~mutation=?t.mutation,
-      ~notifyOnNetworkStatusChange=?t.notifyOnNetworkStatusChange,
-      ~onError=?t.onError->Belt.Option.map(onError =>
-        (. jsApolloError) => onError(ApolloError.fromJs(jsApolloError))
-      ),
-      ~onCompleted=?t.onCompleted->Belt.Option.map((onCompleted, jsData) =>
-        onCompleted(jsData->safeParse)
-      ),
-      ~optimisticResponse=?t.optimisticResponse->Belt.Option.map((optimisticResponse, variables) =>
-        optimisticResponse(variables)->serialize
-      ),
-      ~refetchQueries=?t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
-      ~update=?t.update->Belt.Option.map(MutationUpdaterFn.toJs(~safeParse)),
-      ~variables=?t.variables->Belt.Option.map(v => v->serializeVariables->mapJsVariables),
-      (),
-    )
+  ) => {
+    awaitRefetchQueries: ?t.awaitRefetchQueries,
+    context: ?t.context,
+    client: ?t.client,
+    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(FetchPolicy__noCacheExtracted.toJs),
+    ignoreResults: ?t.ignoreResults,
+    mutation: ?t.mutation,
+    notifyOnNetworkStatusChange: ?t.notifyOnNetworkStatusChange,
+    onError: ?t.onError->Belt.Option.map((onError, jsApolloError) =>
+      onError(ApolloError.fromJs(jsApolloError))
+    ),
+    onCompleted: ?t.onCompleted->Belt.Option.map((onCompleted, jsData) =>
+      onCompleted(jsData->safeParse)
+    ),
+    optimisticResponse: ?t.optimisticResponse->Belt.Option.map((optimisticResponse, variables) =>
+      optimisticResponse(variables)->serialize
+    ),
+    refetchQueries: ?t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
+    update: ?t.update->Belt.Option.map(MutationUpdaterFn.toJs(~safeParse)),
+    variables: ?t.variables->Belt.Option.map(v => v->serializeVariables->mapJsVariables),
+  }
 }
 
 module MutationResult = {
@@ -892,23 +864,23 @@ module MutationFunctionOptions = {
     type t<'jsData, 'jsVariables> = {
       // We don't allow optional variables because it's not typesafe
       variables: 'jsVariables,
-      optimisticResponse: option<(. 'jsVariables) => 'jsData>,
-      refetchQueries: option<RefetchQueryDescription.Js_.t>,
-      awaitRefetchQueries: option<bool>,
-      update: option<MutationUpdaterFn.Js_.t<'jsData>>,
-      context: option<Js.Json.t>, // actual: option(Context)
-      fetchPolicy: option<WatchQueryFetchPolicy.Js_.t>,
+      optimisticResponse?: 'jsVariables => 'jsData,
+      refetchQueries?: RefetchQueryDescription.Js_.t,
+      awaitRefetchQueries?: bool,
+      update?: MutationUpdaterFn.Js_.t<'jsData>,
+      context?: Js.Json.t, // actual: option<Context>
+      fetchPolicy?: WatchQueryFetchPolicy.Js_.t,
     }
   }
 
   type t<'data, 'variables, 'jsVariables> = {
     variables: 'variables,
-    optimisticResponse: option<'jsVariables => 'data>,
-    refetchQueries: option<RefetchQueryDescription.t>,
-    awaitRefetchQueries: option<bool>,
-    update: option<MutationUpdaterFn.t<'data>>,
-    context: option<Js.Json.t>, // actual: option(Context)
-    fetchPolicy: option<WatchQueryFetchPolicy.t>,
+    optimisticResponse?: 'jsVariables => 'data,
+    refetchQueries?: RefetchQueryDescription.t,
+    awaitRefetchQueries?: bool,
+    update?: MutationUpdaterFn.t<'data>,
+    context?: Js.Json.t, // actual: option(Context)
+    fetchPolicy?: WatchQueryFetchPolicy.t,
   }
 
   let toJs: (
@@ -925,14 +897,14 @@ module MutationFunctionOptions = {
     ~serializeVariables,
   ) => {
     variables: t.variables->serializeVariables->mapJsVariables,
-    optimisticResponse: t.optimisticResponse->Belt.Option.map(optimisticResponse =>
-      (. variables) => optimisticResponse(variables)->serialize
+    optimisticResponse: ?t.optimisticResponse->Belt.Option.map((optimisticResponse, variables) =>
+      optimisticResponse(variables)->serialize
     ),
-    refetchQueries: t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
-    awaitRefetchQueries: t.awaitRefetchQueries,
-    update: t.update->Belt.Option.map(MutationUpdaterFn.toJs(~safeParse)),
-    context: t.context,
-    fetchPolicy: t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
+    refetchQueries: ?t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
+    awaitRefetchQueries: ?t.awaitRefetchQueries,
+    update: ?t.update->Belt.Option.map(MutationUpdaterFn.toJs(~safeParse)),
+    context: ?t.context,
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
   }
 }
 
@@ -989,12 +961,12 @@ module MutationTuple = {
           MutationFunctionOptions.toJs(
             {
               variables,
-              optimisticResponse,
-              refetchQueries,
-              awaitRefetchQueries,
-              update,
-              context,
-              fetchPolicy,
+              ?optimisticResponse,
+              ?refetchQueries,
+              ?awaitRefetchQueries,
+              ?update,
+              ?context,
+              ?fetchPolicy,
             },
             ~mapJsVariables,
             ~safeParse,
@@ -1066,12 +1038,12 @@ module MutationTuple__noVariables = {
           MutationFunctionOptions.toJs(
             {
               variables,
-              optimisticResponse,
-              refetchQueries,
-              awaitRefetchQueries,
-              update,
-              context,
-              fetchPolicy,
+              ?optimisticResponse,
+              ?refetchQueries,
+              ?awaitRefetchQueries,
+              ?update,
+              ?context,
+              ?fetchPolicy,
             },
             ~mapJsVariables,
             ~safeParse,
@@ -1169,36 +1141,36 @@ module BaseSubscriptionOptions = {
     //     onSubscriptionComplete?: () => void;
     // }
     type rec t<'jsData, 'jsVariables> = {
-      variables: option<'jsVariables>,
-      fetchPolicy: option<FetchPolicy.t>,
-      shouldResubscribe: option<(. t<'jsData, 'jsVariables>) => bool>,
-      client: option<ApolloClient.t>,
-      skip: option<bool>,
-      onSubscriptionData: option<(. OnSubscriptionDataOptions.Js_.t<'jsData>) => unit>,
-      onSubscriptionComplete: option<unit => unit>,
+      variables?: 'jsVariables,
+      fetchPolicy?: FetchPolicy.t,
+      shouldResubscribe?: t<'jsData, 'jsVariables> => bool,
+      client?: ApolloClient.t,
+      skip?: bool,
+      onSubscriptionData?: OnSubscriptionDataOptions.Js_.t<'jsData> => unit,
+      onSubscriptionComplete?: unit => unit,
     }
   }
 
   type rec t<'data, 'jsVariables> = {
-    variables: option<'jsVariables>,
-    fetchPolicy: option<FetchPolicy.t>,
-    shouldResubscribe: option<t<'data, 'jsVariables> => bool>,
-    client: option<ApolloClient.t>,
-    skip: option<bool>,
-    onSubscriptionData: option<OnSubscriptionDataOptions.t<'data> => unit>,
-    onSubscriptionComplete: option<unit => unit>,
+    variables?: 'jsVariables,
+    fetchPolicy?: FetchPolicy.t,
+    shouldResubscribe?: t<'data, 'jsVariables> => bool,
+    client?: ApolloClient.t,
+    skip?: bool,
+    onSubscriptionData?: OnSubscriptionDataOptions.t<'data> => unit,
+    onSubscriptionComplete?: unit => unit,
   }
 
   let fromJs: Js_.t<'jsData, 'jsVariables> => t<'data, 'jsVariables> = js => {
-    variables: js.variables,
-    fetchPolicy: js.fetchPolicy,
+    variables: ?js.variables,
+    fetchPolicy: ?js.fetchPolicy,
     // shouldResubscribe: what to do here?
-    shouldResubscribe: Obj.magic(js.shouldResubscribe),
-    client: js.client,
-    skip: js.skip,
+    shouldResubscribe: ?Obj.magic(js.shouldResubscribe),
+    client: ?js.client,
+    skip: ?js.skip,
     // onSubscriptionData: what to do here?
-    onSubscriptionData: Obj.magic(js.onSubscriptionData),
-    onSubscriptionComplete: js.onSubscriptionComplete,
+    onSubscriptionData: ?Obj.magic(js.onSubscriptionData),
+    onSubscriptionComplete: ?js.onSubscriptionComplete,
   }
 }
 
@@ -1207,34 +1179,29 @@ module SubscriptionHookOptions = {
     // export interface SubscriptionHookOptions<TData = any, TVariables = OperationVariables> extends BaseSubscriptionOptions<TData, TVariables> {
     //     subscription?: DocumentNode;
     // }
-    type t<'jsData, 'jsVariables>
-
-    // NOTE: We are using @obj here because passing properties that are defined with a value of undefined has effects
-    @obj
-    external make: (
-      ~subscription: Graphql.documentNode=?,
+    type t<'jsData, 'jsVariables> = {
+      subscription?: Graphql.documentNode,
       // ...extends BaseSubscriptionOptions
       // Intentionally restricted to not be non-optional. `option(unit)` does not compile cleanly to `undefined`
-      ~variables: 'jsVariables,
-      ~fetchPolicy: FetchPolicy.t=?,
-      ~shouldResubscribe: (. BaseSubscriptionOptions.Js_.t<'jsData, 'jsVariables>) => bool=?,
-      ~client: ApolloClient.t=?,
-      ~skip: bool=?,
-      ~onSubscriptionData: (. OnSubscriptionDataOptions.Js_.t<'jsData>) => unit=?,
-      ~onSubscriptionComplete: unit => unit=?,
-      unit,
-    ) => t<'jsData, 'jsVariables> = ""
+      variables: 'jsVariables,
+      fetchPolicy?: FetchPolicy.Js_.t,
+      shouldResubscribe?: BaseSubscriptionOptions.Js_.t<'jsData, 'jsVariables> => bool,
+      client?: ApolloClient.t,
+      skip?: bool,
+      onSubscriptionData?: OnSubscriptionDataOptions.Js_.t<'jsData> => unit,
+      onSubscriptionComplete?: unit => unit,
+    }
   }
 
   type t<'data, 'variables, 'jsVariables> = {
-    subscription: option<Graphql.documentNode>,
+    subscription?: Graphql.documentNode,
     variables: 'variables,
-    fetchPolicy: option<FetchPolicy.t>,
-    shouldResubscribe: option<BaseSubscriptionOptions.t<'data, 'jsVariables> => bool>,
-    client: option<ApolloClient.t>,
-    skip: option<bool>,
-    onSubscriptionData: option<OnSubscriptionDataOptions.t<'data> => unit>,
-    onSubscriptionComplete: option<unit => unit>,
+    fetchPolicy?: FetchPolicy.t,
+    shouldResubscribe?: BaseSubscriptionOptions.t<'data, 'jsVariables> => bool,
+    client?: ApolloClient.t,
+    skip?: bool,
+    onSubscriptionData?: OnSubscriptionDataOptions.t<'data> => unit,
+    onSubscriptionComplete?: unit => unit,
   }
 
   let toJs: (
@@ -1242,24 +1209,22 @@ module SubscriptionHookOptions = {
     ~mapJsVariables: 'jsVariables => 'jsVariables,
     ~safeParse: Types.safeParse<'data, 'jsData>,
     ~serializeVariables: 'variables => 'jsVariables,
-  ) => Js_.t<'jsData, 'jsVariables> = (t, ~mapJsVariables, ~safeParse, ~serializeVariables) =>
-    Js_.make(
-      ~subscription=?t.subscription,
-      ~variables=t.variables->serializeVariables->mapJsVariables,
-      ~fetchPolicy=?t.fetchPolicy,
-      ~shouldResubscribe=?t.shouldResubscribe->Belt.Option.map(shouldResubscribe =>
-        (. jsBaseSubscriptionOptions) =>
-          shouldResubscribe(jsBaseSubscriptionOptions->BaseSubscriptionOptions.fromJs)
-      ),
-      ~client=?t.client,
-      ~skip=?t.skip,
-      ~onSubscriptionData=?t.onSubscriptionData->Belt.Option.map(onSubscriptionData =>
-        (. jsOnSubscriptionDataOptions) =>
-          onSubscriptionData(
-            jsOnSubscriptionDataOptions->OnSubscriptionDataOptions.fromJs(~safeParse),
-          )
-      ),
-      ~onSubscriptionComplete=?t.onSubscriptionComplete,
-      (),
-    )
+  ) => Js_.t<'jsData, 'jsVariables> = (t, ~mapJsVariables, ~safeParse, ~serializeVariables) => {
+    subscription: ?t.subscription,
+    variables: t.variables->serializeVariables->mapJsVariables,
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(FetchPolicy.toJs),
+    shouldResubscribe: ?t.shouldResubscribe->Belt.Option.map((
+      shouldResubscribe,
+      jsBaseSubscriptionOptions,
+    ) => shouldResubscribe(jsBaseSubscriptionOptions->BaseSubscriptionOptions.fromJs)),
+    client: ?t.client,
+    skip: ?t.skip,
+    onSubscriptionData: ?t.onSubscriptionData->Belt.Option.map((
+      onSubscriptionData,
+      jsOnSubscriptionDataOptions,
+    ) =>
+      onSubscriptionData(jsOnSubscriptionDataOptions->OnSubscriptionDataOptions.fromJs(~safeParse))
+    ),
+    onSubscriptionComplete: ?t.onSubscriptionComplete,
+  }
 }

--- a/src/@apollo/client/utilities/policies/ApolloClient__Utilities_Policies_Pagination.res
+++ b/src/@apollo/client/utilities/policies/ApolloClient__Utilities_Policies_Pagination.res
@@ -17,25 +17,25 @@ module KeyArgs = ApolloClient__Cache_InMemory_Policies_FieldPolicy.FieldPolicy_K
 module Js_ = {
   // export declare function concatPagination<T = Reference>(keyArgs?: KeyArgs): FieldPolicy<T[]>;
   @module("@apollo/client/utilities") @val
-  external concatPagination: (. option<KeyArgs.Js_.t>) => FieldPolicy.Js_.t<'existing> =
+  external concatPagination: option<KeyArgs.Js_.t> => FieldPolicy.Js_.t<'existing> =
     "concatPagination"
 
   // export declare function offsetLimitPagination<T = Reference>(keyArgs?: KeyArgs): FieldPolicy<T[]>;
   @module("@apollo/client/utilities") @val
-  external offsetLimitPagination: (. option<KeyArgs.Js_.t>) => FieldPolicy.Js_.t<'existing> =
+  external offsetLimitPagination: option<KeyArgs.Js_.t> => FieldPolicy.Js_.t<'existing> =
     "offsetLimitPagination"
 
   // export declare function relayStylePagination<TNode = Reference>(keyArgs?: KeyArgs): FieldPolicy<TInternalRelay<TNode>>;
   @module("@apollo/client/utilities") @val
-  external relayStylePagination: (. option<KeyArgs.Js_.t>) => FieldPolicy.Js_.t<'existing> =
+  external relayStylePagination: option<KeyArgs.Js_.t> => FieldPolicy.Js_.t<'existing> =
     "relayStylePagination"
 }
 
 let concatPagination: KeyArgs.t => FieldPolicy.Js_.t<'existing> = keyArgs =>
-  Js_.concatPagination(. Some(keyArgs->KeyArgs.toJs))
+  Js_.concatPagination(Some(keyArgs->KeyArgs.toJs))
 
 let offsetLimitPagination: KeyArgs.t => FieldPolicy.Js_.t<'existing> = keyArgs =>
-  Js_.offsetLimitPagination(. Some(keyArgs->KeyArgs.toJs))
+  Js_.offsetLimitPagination(Some(keyArgs->KeyArgs.toJs))
 
 let relayStylePagination: KeyArgs.t => FieldPolicy.Js_.t<'existing> = keyArgs =>
-  Js_.relayStylePagination(. Some(keyArgs->KeyArgs.toJs))
+  Js_.relayStylePagination(Some(keyArgs->KeyArgs.toJs))

--- a/src/subscriptions-transport-ws/ApolloClient__SubscriptionsTransportWs.res
+++ b/src/subscriptions-transport-ws/ApolloClient__SubscriptionsTransportWs.res
@@ -84,38 +84,39 @@ module ClientOptions = {
     //     inactivityTimeout?: number;
     // }
     type t = {
-      connectionParams: option<ConnectionParamsOptions.Js_.t>,
-      timeout: option<int>,
-      reconnect: option<bool>,
-      reconnectionAttempts: option<int>,
-      connectionCallback: option<(~error: array<Js.Exn.t>, ~result: option<Js.Json.t>) => unit>,
+      connectionParams?: ConnectionParamsOptions.Js_.t,
+      timeout?: int,
+      reconnect?: bool,
+      reconnectionAttempts?: int,
+      connectionCallback?: (~error: array<Js.Exn.t>, ~result: option<Js.Json.t>) => unit,
       @as("lazy")
-      lazy_: option<bool>,
-      inactivityTimeout: option<int>,
+      lazy_?: bool,
+      inactivityTimeout?: int,
     }
   }
 
   type t = {
-    connectionParams: option<ConnectionParamsOptions.t>,
-    timeout: option<int>,
-    reconnect: option<bool>,
-    reconnectionAttempts: option<int>,
-    connectionCallback: option<(~error: array<Js.Exn.t>, ~result: option<Js.Json.t>) => unit>,
+    connectionParams?: ConnectionParamsOptions.t,
+    timeout?: int,
+    reconnect?: bool,
+    reconnectionAttempts?: int,
+    connectionCallback?: (~error: array<Js.Exn.t>, ~result: option<Js.Json.t>) => unit,
     @as("lazy")
-    lazy_: option<bool>,
-    inactivityTimeout: option<int>,
+    lazy_?: bool,
+    inactivityTimeout?: int,
   }
 
   let toJs: t => Js_.t = t => {
-    connectionParams: t.connectionParams->Belt.Option.map(ConnectionParamsOptions.toJs),
-    timeout: t.timeout,
-    reconnect: t.reconnect,
-    reconnectionAttempts: t.reconnectionAttempts,
-    connectionCallback: t.connectionCallback,
-    lazy_: t.lazy_,
-    inactivityTimeout: t.inactivityTimeout,
+    connectionParams: ?t.connectionParams->Belt.Option.map(ConnectionParamsOptions.toJs),
+    timeout: ?t.timeout,
+    reconnect: ?t.reconnect,
+    reconnectionAttempts: ?t.reconnectionAttempts,
+    connectionCallback: ?t.connectionCallback,
+    lazy_: ?t.lazy_,
+    inactivityTimeout: ?t.inactivityTimeout,
   }
 
+  @deprecated("Construct the record directly instead")
   let make = (
     ~connectionParams=?,
     ~timeout=?,
@@ -126,13 +127,13 @@ module ClientOptions = {
     ~inactivityTimeout=?,
     (),
   ): t => {
-    connectionParams,
-    timeout,
-    reconnect,
-    reconnectionAttempts,
-    connectionCallback,
-    lazy_,
-    inactivityTimeout,
+    ?connectionParams,
+    ?timeout,
+    ?reconnect,
+    ?reconnectionAttempts,
+    ?connectionCallback,
+    ?lazy_,
+    ?inactivityTimeout,
   }
 }
 


### PR DESCRIPTION
Resolves #151

**BREAKING**: Requires optional record fields support from `rescript@^10.0.0`

**Potentially disruptive** (but hopefully not): Drops peer-dependency for `bs-platform`. It seems pretty likely that most people would be moved to at least `rescript@9` (which was just a re-name) or `melange` by this point.