### PR TITLE
Updating to Latest Dependencies Rescript version 11, Rescript/React version 12

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -21,5 +21,6 @@
     }
   ],
   "suffix": ".bs.js",
-  "bs-dependencies": ["@reasonml-community/graphql-ppx", "@rescript/react"]
+  "bs-dependencies": ["@reasonml-community/graphql-ppx", "@rescript/react"],
+  "uncurried": false
 }

--- a/package.json
+++ b/package.json
@@ -20,29 +20,21 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@apollo/client": "^3.5.0",
-    "@reasonml-community/graphql-ppx": "^1.0.0",
+    "@apollo/client": "^3.10.8",
+    "@reasonml-community/graphql-ppx": "^1.2.3",
     "@rescript/react": "~0.11.0",
-    "rescript": "~10.1.2",
-    "graphql": "^14.0.0",
+    "rescript": "~10.1.4",
+    "graphql": "^16.9.0",
     "jest": "26.5.3",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "subscriptions-transport-ws": "^0.9.17"
   },
   "peerDependencies": {
     "@apollo/client": "^3.5.0",
-    "@reasonml-community/graphql-ppx": "^1.0.0",
+    "@reasonml-community/graphql-ppx": "^1.0.0 || ^1.2.3",
     "@rescript/react": "~0.10. || ~0.11.0",
     "bs-platform": "^8.2.0 || ^9.0.0",
     "rescript": "^9.0.0 || ^10.0.0"
-  },
-  "peerDependenciesMeta": {
-    "rescript": {
-      "optional": true
-    },
-    "bs-platform": {
-      "optional": true
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,5 +36,13 @@
     "@rescript/react": "~0.10.0 || ~0.11.0 || ~0.12.0",
     "bs-platform": "^8.2.0 || ^9.0.0",
     "rescript": "^9.0.0 || ^10.0.0 || ^11.0.0"
+  },
+  "peerDependenciesMeta": {
+    "rescript": {
+      "optional": true
+    },
+    "bs-platform": {
+      "optional": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "devDependencies": {
     "@apollo/client": "^3.10.8",
     "@reasonml-community/graphql-ppx": "^1.2.3",
-    "@rescript/react": "~0.11.0",
-    "rescript": "~10.1.4",
+    "@rescript/react": "~0.12.2",
+    "rescript": "~11.1.2",
     "graphql": "^16.9.0",
     "jest": "26.5.3",
     "react": "^18.3.1",
@@ -33,8 +33,8 @@
   "peerDependencies": {
     "@apollo/client": "^3.5.0",
     "@reasonml-community/graphql-ppx": "^1.0.0 || ^1.2.3",
-    "@rescript/react": "~0.10. || ~0.11.0",
+    "@rescript/react": "~0.10.0 || ~0.11.0 || ~0.12.0",
     "bs-platform": "^8.2.0 || ^9.0.0",
-    "rescript": "^9.0.0 || ^10.0.0"
+    "rescript": "^9.0.0 || ^10.0.0 || ^11.0.0"
   }
 }


### PR DESCRIPTION
Updated to latest versions 

@apollo/client: 3.5.0 -> 3.10.8
@reasonml-community/graphql-ppx:  1.0.0 -> 1.2.3
@rescript/react: 0.11.0 -> 0.12.2
rescript: 10.1.2 -> 11.1.2
graphql: 14.0.0 -> 16.9.0
react: 18.2.0 -> 18.3.1
react-dom: 18.2.0 -> 18.3.1

Breaking change was new rescript uncurried mode, should be backward compatible.