### PR TITLE
Explicitly uncurry rescript-apollo-client

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -21,5 +21,6 @@
     }
   ],
   "suffix": ".bs.js",
-  "bs-dependencies": ["@reasonml-community/graphql-ppx", "@rescript/react"]
+  "bs-dependencies": ["@reasonml-community/graphql-ppx", "@rescript/react"],
+  "uncurried": false
 }

--- a/package.json
+++ b/package.json
@@ -20,29 +20,21 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@apollo/client": "^3.5.0",
-    "@reasonml-community/graphql-ppx": "^1.0.0",
+    "@apollo/client": "^3.10.8",
+    "@reasonml-community/graphql-ppx": "^1.2.3",
     "@rescript/react": "~0.11.0",
-    "rescript": "~10.1.2",
-    "graphql": "^14.0.0",
+    "rescript": "~10.1.4",
+    "graphql": "^16.9.0",
     "jest": "26.5.3",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "subscriptions-transport-ws": "^0.9.17"
   },
   "peerDependencies": {
     "@apollo/client": "^3.5.0",
-    "@reasonml-community/graphql-ppx": "^1.0.0",
+    "@reasonml-community/graphql-ppx": "^1.0.0 || ^1.2.3",
     "@rescript/react": "~0.10. || ~0.11.0",
     "bs-platform": "^8.2.0 || ^9.0.0",
     "rescript": "^9.0.0 || ^10.0.0"
-  },
-  "peerDependenciesMeta": {
-    "rescript": {
-      "optional": true
-    },
-    "bs-platform": {
-      "optional": true
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,5 +36,13 @@
     "@rescript/react": "~0.10.0 || ~0.11.0 || ~0.12.0",
     "bs-platform": "^8.2.0 || ^9.0.0",
     "rescript": "^9.0.0 || ^10.0.0 || ^11.0.0"
+  },
+  "peerDependenciesMeta": {
+    "rescript": {
+      "optional": true
+    },
+    "bs-platform": {
+      "optional": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "devDependencies": {
     "@apollo/client": "^3.10.8",
     "@reasonml-community/graphql-ppx": "^1.2.3",
-    "@rescript/react": "~0.11.0",
-    "rescript": "~10.1.4",
+    "@rescript/react": "~0.12.2",
+    "rescript": "~11.1.2",
     "graphql": "^16.9.0",
     "jest": "26.5.3",
     "react": "^18.3.1",
@@ -33,8 +33,8 @@
   "peerDependencies": {
     "@apollo/client": "^3.5.0",
     "@reasonml-community/graphql-ppx": "^1.0.0 || ^1.2.3",
-    "@rescript/react": "~0.10. || ~0.11.0",
+    "@rescript/react": "~0.10.0 || ~0.11.0 || ~0.12.0",
     "bs-platform": "^8.2.0 || ^9.0.0",
-    "rescript": "^9.0.0 || ^10.0.0"
+    "rescript": "^9.0.0 || ^10.0.0 || ^11.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,12 +22,13 @@
   "devDependencies": {
     "@apollo/client": "^3.10.8",
     "@reasonml-community/graphql-ppx": "^1.2.3",
+    "@rescript/core": "^1.6.1",
     "@rescript/react": "~0.12.2",
-    "rescript": "~11.1.2",
     "graphql": "^16.9.0",
     "jest": "26.5.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "rescript": "~11.1.2",
     "subscriptions-transport-ws": "^0.9.17"
   },
   "peerDependencies": {

--- a/rescript.json
+++ b/rescript.json
@@ -1,0 +1,25 @@
+{
+  "name": "rescript-apollo-client",
+  "package-specs": [
+    {
+      "module": "commonjs",
+      "in-source": true
+    }
+  ],
+  "reason": {
+    "react-jsx": 3
+  },
+  "refmt": 3,
+  "jsx": {
+    "version": 4,
+    "mode": "automatic"
+  },
+  "sources": [
+    {
+      "dir": "src",
+      "subdirs": true
+    }
+  ],
+  "suffix": ".bs.js",
+  "bs-dependencies": ["@reasonml-community/graphql-ppx", "@rescript/react"]
+}

--- a/rescript.json
+++ b/rescript.json
@@ -21,5 +21,9 @@
     }
   ],
   "suffix": ".bs.js",
-  "bs-dependencies": ["@reasonml-community/graphql-ppx", "@rescript/react"]
+  "bs-dependencies": [
+    "@reasonml-community/graphql-ppx",
+    "@rescript/react",
+    "@rescript/core"
+  ]
 }

--- a/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.res
+++ b/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.res
@@ -196,7 +196,7 @@ module ApolloCache = {
         (),
       )
       ->Js.toOption
-      ->Belt.Option.map(fragment => safeParse(fragment))
+      ->Belt.Option.map(safeParse(_))
     }
 
     let readQuery = (
@@ -230,7 +230,7 @@ module ApolloCache = {
         ~optimistic,
       )
       ->Js.toOption
-      ->Belt.Option.mapU(safeParse)
+      ->Belt.Option.map(safeParse(_))
     }
 
     let writeFragment = (
@@ -330,7 +330,7 @@ module ApolloCache = {
           ->Js.Nullable.fromOption,
       )
       ->Js.toOption
-      ->Belt.Option.mapU(safeParse)
+      ->Belt.Option.map(safeParse(_))
     }
 
     let updateFragment = (
@@ -367,7 +367,7 @@ module ApolloCache = {
           ->Js.Nullable.fromOption,
       )
       ->Js.toOption
-      ->Belt.Option.mapU(safeParse)
+      ->Belt.Option.map(safeParse(_))
     }
 
     preserveJsPropsAndContext(

--- a/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.res
+++ b/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.res
@@ -196,7 +196,7 @@ module ApolloCache = {
         (),
       )
       ->Js.toOption
-      ->Belt.Option.mapU(safeParse)
+      ->Belt.Option.map(fragment => safeParse(fragment))
     }
 
     let readQuery = (

--- a/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.res
+++ b/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.res
@@ -186,17 +186,17 @@ module ApolloCache = {
       js
       ->Js_.readFragment(
         ~options={
-          id: id,
+          id,
           fragment: Fragment.query,
-          fragmentName: fragmentName,
-          optimistic: optimistic,
-          canonizeResults: canonizeResults,
+          fragmentName,
+          optimistic,
+          canonizeResults,
         },
         ~optimistic?,
         (),
       )
       ->Js.toOption
-      ->Belt.Option.map(safeParse)
+      ->Belt.Option.mapU(safeParse)
     }
 
     let readQuery = (
@@ -218,11 +218,11 @@ module ApolloCache = {
       ->Js_.readQuery(
         ~options=DataProxy.ReadQueryOptions.toJs(
           {
-            id: id,
+            id,
             query: Operation.query,
-            variables: variables,
-            optimistic: optimistic,
-            canonizeResults: canonizeResults,
+            variables,
+            optimistic,
+            canonizeResults,
           },
           ~mapJsVariables,
           ~serializeVariables=Operation.serializeVariables,
@@ -230,7 +230,7 @@ module ApolloCache = {
         ~optimistic,
       )
       ->Js.toOption
-      ->Belt.Option.map(safeParse)
+      ->Belt.Option.mapU(safeParse)
     }
 
     let writeFragment = (
@@ -247,12 +247,12 @@ module ApolloCache = {
       js->Js_.writeFragment(
         ~options=DataProxy.WriteFragmentOptions.toJs(
           {
-            broadcast: broadcast,
-            data: data,
-            id: id,
+            broadcast,
+            data,
+            id,
             fragment: Fragment.query,
-            fragmentName: fragmentName,
-            overwrite: overwrite,
+            fragmentName,
+            overwrite,
           },
           ~serialize=Fragment.serialize,
         ),
@@ -275,12 +275,12 @@ module ApolloCache = {
       js->Js_.writeQuery(
         ~options=DataProxy.WriteQueryOptions.toJs(
           {
-            broadcast: broadcast,
-            data: data,
-            id: id,
+            broadcast,
+            data,
+            id,
             query: Operation.query,
-            variables: variables,
-            overwrite: overwrite,
+            variables,
+            overwrite,
           },
           ~mapJsVariables,
           ~serialize=Operation.serialize,
@@ -307,28 +307,30 @@ module ApolloCache = {
       let safeParse = Utils.safeParse(Operation.parse)
 
       js
-      ->Js_.updateQuery(~options=DataProxy.UpdateQueryOptions.toJs(
-        {
-          optimistic: optimistic,
-          canonizeResults: canonizeResults,
-          broadcast: broadcast,
-          id: id,
-          query: Operation.query,
-          variables: variables,
-          overwrite: overwrite,
-        },
-        ~mapJsVariables,
-        ~serializeVariables=Operation.serializeVariables,
-      ), ~update=jsData =>
-        jsData
-        ->Js.nullToOption
-        ->Belt.Option.map(Operation.parse)
-        ->update
-        ->Belt.Option.map(Operation.serialize)
-        ->Js.Nullable.fromOption
+      ->Js_.updateQuery(
+        ~options=DataProxy.UpdateQueryOptions.toJs(
+          {
+            optimistic,
+            canonizeResults,
+            broadcast,
+            id,
+            query: Operation.query,
+            variables,
+            overwrite,
+          },
+          ~mapJsVariables,
+          ~serializeVariables=Operation.serializeVariables,
+        ),
+        ~update=jsData =>
+          jsData
+          ->Js.nullToOption
+          ->Belt.Option.map(Operation.parse)
+          ->update
+          ->Belt.Option.map(Operation.serialize)
+          ->Js.Nullable.fromOption,
       )
       ->Js.toOption
-      ->Belt.Option.map(safeParse)
+      ->Belt.Option.mapU(safeParse)
     }
 
     let updateFragment = (
@@ -346,35 +348,37 @@ module ApolloCache = {
       let safeParse = Utils.safeParse(Fragment.parse)
 
       js
-      ->Js_.updateFragment(~options=DataProxy.UpdateFragmentOptions.toJs({
-        optimistic: optimistic,
-        canonizeResults: canonizeResults,
-        broadcast: broadcast,
-        id: id,
-        fragment: Fragment.query,
-        fragmentName: fragmentName,
-        overwrite: overwrite,
-      }), ~update=jsData =>
-        jsData
-        ->Js.nullToOption
-        ->Belt.Option.map(Fragment.parse)
-        ->update
-        ->Belt.Option.map(Fragment.serialize)
-        ->Js.Nullable.fromOption
+      ->Js_.updateFragment(
+        ~options=DataProxy.UpdateFragmentOptions.toJs({
+          optimistic,
+          canonizeResults,
+          broadcast,
+          id,
+          fragment: Fragment.query,
+          fragmentName,
+          overwrite,
+        }),
+        ~update=jsData =>
+          jsData
+          ->Js.nullToOption
+          ->Belt.Option.map(Fragment.parse)
+          ->update
+          ->Belt.Option.map(Fragment.serialize)
+          ->Js.Nullable.fromOption,
       )
       ->Js.toOption
-      ->Belt.Option.map(safeParse)
+      ->Belt.Option.mapU(safeParse)
     }
 
     preserveJsPropsAndContext(
       js,
       {
-        readFragment: readFragment,
-        readQuery: readQuery,
-        writeFragment: writeFragment,
-        writeQuery: writeQuery,
-        updateFragment: updateFragment,
-        updateQuery: updateQuery,
+        readFragment,
+        readQuery,
+        writeFragment,
+        writeQuery,
+        updateFragment,
+        updateQuery,
       },
     )
   }

--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies.res
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies.res
@@ -69,7 +69,7 @@ module TypePolicy = {
       queryType: option<bool>,
       mutationType: option<bool>,
       subscriptionType: option<bool>,
-      fields: option<Js.Dict.t<FieldsUnion.t>>,
+      fields: option<RescriptCore.Dict.t<FieldsUnion.t>>,
     }
   }
 
@@ -92,7 +92,7 @@ module TypePolicy = {
     fields: option<t_fields>,
   }
 
-  let toJs: (. t) => Js_.t = (. t) => {
+  let toJs: t => Js_.t = t => {
     keyFields: t.keyFields->Belt.Option.map(KeyArgs.toJs),
     queryType: t.queryType,
     mutationType: t.mutationType,
@@ -114,7 +114,7 @@ module TypePolicy = {
           fieldReadFunction->FieldReadFunction.toJs->Js_.FieldsUnion.fieldReadFunction
         },
       ))
-      ->Js.Dict.fromArray
+      ->RescriptCore.Dict.fromArray
     ),
   }
 
@@ -126,11 +126,11 @@ module TypePolicy = {
     ~subscriptionType: bool=?,
     unit,
   ) => t = (~fields=?, ~keyFields=?, ~mutationType=?, ~queryType=?, ~subscriptionType=?, ()) => {
-    fields: fields,
-    keyFields: keyFields,
-    mutationType: mutationType,
-    queryType: queryType,
-    subscriptionType: subscriptionType,
+    fields,
+    keyFields,
+    mutationType,
+    queryType,
+    subscriptionType,
   }
 }
 
@@ -139,7 +139,7 @@ module TypePolicies = {
     // export declare type TypePolicies = {
     //     [__typename: string]: TypePolicy;
     // };
-    type t = Js.Dict.t<TypePolicy.Js_.t>
+    type t = RescriptCore.Dict.t<TypePolicy.Js_.t>
   }
 
   type typename = string
@@ -147,11 +147,13 @@ module TypePolicies = {
   type t = array<(typename, TypePolicy.t)>
 
   let toJs: t => Js_.t = t =>
-    t->Belt.Array.map(((key, policy)) => (key, TypePolicy.toJs(. policy)))->Js.Dict.fromArray
+    t
+    ->Belt.Array.map(((key, policy)) => (key, TypePolicy.toJs(policy)))
+    ->RescriptCore.Dict.fromArray
 }
 
 module PossibleTypesMap = {
-  type t = Js.Dict.t<array<string>>
+  type t = RescriptCore.Dict.t<array<string>>
   module Js_ = {
     // export declare type PossibleTypesMap = {
     //     [supertype: string]: string[];

--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies_FieldPolicy.res
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies_FieldPolicy.res
@@ -5,7 +5,7 @@ module ReadFieldFunction = ApolloClient__Cache_Core_Types_Common.ReadFieldFuncti
 module ToReferenceFunction = ApolloClient__Cache_Core_Types_Common.ToReferenceFunction
 
 module StorageType = {
-  type t = Js.Dict.t<Js.Json.t>
+  type t = RescriptCore.Dict.t<Js.Json.t>
   module Js_ = {
     type t = t
   }
@@ -30,11 +30,11 @@ module FieldFunctionOptions = {
     //     mergeObjects<T extends StoreObject | Reference>(existing: T, incoming: T): T | undefined;
     // }
     type t = {
-      args: Js.nullable<Js.Dict.t<Js.Json.t>>,
+      args: Js.nullable<RescriptCore.Dict.t<Js.Json.t>>,
       fieldName: string,
       storeFieldName: string,
       field: Js.nullable<FieldNode.t>,
-      variables: option<Js.Dict.t<Js.Json.t>>,
+      variables: option<RescriptCore.Dict.t<Js.Json.t>>,
       isReference: bool,
       toReference: unimplemented,
       readField: unimplemented,
@@ -52,11 +52,11 @@ module FieldFunctionOptions = {
   }
 
   type t = {
-    args: Js.nullable<Js.Dict.t<Js.Json.t>>,
+    args: Js.nullable<RescriptCore.Dict.t<Js.Json.t>>,
     fieldName: string,
     storeFieldName: string,
     field: Js.nullable<FieldNode.t>,
-    variables: option<Js.Dict.t<Js.Json.t>>,
+    variables: option<RescriptCore.Dict.t<Js.Json.t>>,
     isReference: bool,
     toReference: unimplemented,
     storage: Js.nullable<StorageType.t>,

--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies_FieldPolicy.res
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies_FieldPolicy.res
@@ -103,7 +103,7 @@ module FieldMergeFunction = {
     type t<'existing> = ('existing, 'existing, FieldFunctionOptions.Js_.t) => 'existing
   }
 
-  let toJs: t<'existing> => Js_.t<'existing> = (t, existing, incoming, jsFieldFunctionOptions) =>
+  let toJs: t<'existing> => Js_.t<'existing> = t => (existing, incoming, jsFieldFunctionOptions) =>
     t(existing, incoming, jsFieldFunctionOptions->FieldFunctionOptions.fromJs)
 }
 
@@ -144,7 +144,7 @@ module FieldReadFunction = {
     type t<'existing> = (option<'existing>, FieldFunctionOptions.Js_.t) => 'existing
   }
 
-  let toJs: t<'existing> => Js_.t<'existing> = (t, existing, jsFieldFunctionOptions) =>
+  let toJs: t<'existing> => Js_.t<'existing> = t => (existing, jsFieldFunctionOptions) =>
     t(existing, jsFieldFunctionOptions->FieldFunctionOptions.fromJs)
 }
 

--- a/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
+++ b/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
@@ -200,7 +200,7 @@ module ApolloClientOptions = {
     type t = {
       uri: option<UriFunction.Js_.t>,
       credentials: option<string>,
-      headers: option<Js.Dict.t<string>>,
+      headers: option<RescriptCore.Dict.t<string>>,
       link: option<ApolloLink.Js_.t>,
       cache: ApolloCache.t<Js.Json.t>, // Non-Js_ ApolloCache is correct here
       ssrForceFetchDelay: option<int>,
@@ -220,7 +220,7 @@ module ApolloClientOptions = {
   type t = {
     uri: option<UriFunction.t>,
     credentials: option<string>,
-    headers: option<Js.Dict.t<string>>,
+    headers: option<RescriptCore.Dict.t<string>>,
     link: option<ApolloLink.t>,
     cache: ApolloCache.t<Js.Json.t>,
     ssrForceFetchDelay: option<int>,
@@ -574,7 +574,7 @@ let preserveJsPropsAndContext: (Js_.t, t) => t = %raw(`
 let make: (
   ~uri: UriFunction.t=?,
   ~credentials: string=?,
-  ~headers: Js.Dict.t<string>=?,
+  ~headers: RescriptCore.Dict.t<string>=?,
   ~link: ApolloLink.t=?,
   ~cache: ApolloCache.t<Js.Json.t>,
   ~ssrForceFetchDelay: int=?,

--- a/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
+++ b/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
@@ -698,9 +698,9 @@ let make: (
     , _)
   }
 
-  let onClearStore = (~cb) => jsClient->Js_.onClearStore(~cb)
+  let onClearStore = t => (~cb) => jsClient->Js_.onClearStore(t, ~cb)
 
-  let onResetStore = (~cb) => jsClient->Js_.onResetStore(~cb)
+  let onResetStore = t => (~cb) => jsClient->Js_.onResetStore(t, ~cb)
 
   let query = (
     type data variables jsVariables,
@@ -777,7 +777,7 @@ let make: (
       (),
     )
     ->Js.toOption
-    ->Belt.Option.map(safeParse)
+    ->Belt.Option.mapU(safeParse)
   }
 
   let readQuery = (
@@ -811,7 +811,7 @@ let make: (
       ~optimistic,
     )
     ->Js.toOption
-    ->Belt.Option.map(safeParse)
+    ->Belt.Option.mapU(safeParse)
   }
 
   let resetStore: unit => Js.Promise.t<
@@ -1013,7 +1013,7 @@ let make: (
       ->Js.Nullable.fromOption
     )
     ->Js.toOption
-    ->Belt.Option.map(safeParse)
+    ->Belt.Option.mapU(safeParse)
   }
 
   let updateFragment = (
@@ -1048,7 +1048,7 @@ let make: (
       ->Js.Nullable.fromOption
     )
     ->Js.toOption
-    ->Belt.Option.map(safeParse)
+    ->Belt.Option.mapU(safeParse)
   }
 
   preserveJsPropsAndContext(

--- a/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
+++ b/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
@@ -318,11 +318,11 @@ module Js_ = {
 
   // onClearStore(cb: () => Promise<any>): () => void;
   @send
-  external onClearStore: (t, ~cb: unit => Js.Promise.t<unit>, unit) => unit = "onClearStore"
+  external onClearStore: (t, ~cb: unit => Js.Promise.t<unit>) => unit = "onClearStore"
 
   // onResetStore(cb: () => Promise<any>): () => void;
   @send
-  external onResetStore: (t, ~cb: unit => Js.Promise.t<unit>, unit) => unit = "onResetStore"
+  external onResetStore: (t, ~cb: unit => Js.Promise.t<unit>) => unit = "onResetStore"
 
   // query<T = any, TVariables = OperationVariables>(options: QueryOptions<TVariables>): Promise<ApolloQueryResult<T>>;
   @send
@@ -436,9 +436,9 @@ type t = {
     'variables,
   ) => Js.Promise.t<Belt.Result.t<FetchResult.t__ok<'data>, ApolloError.t>>,
   @as("rescript_onClearStore")
-  onClearStore: (~cb: unit => Js.Promise.t<unit>, unit) => unit,
+  onClearStore: (~cb: unit => Js.Promise.t<unit>) => unit,
   @as("rescript_onResetStore")
-  onResetStore: (~cb: unit => Js.Promise.t<unit>, unit) => unit,
+  onResetStore: (~cb: unit => Js.Promise.t<unit>) => unit,
   @as("rescript_query")
   query: 'data 'variables 'jsVariables. (
     ~query: module(Operation with
@@ -698,9 +698,9 @@ let make: (
       , _))
   }
 
-  let onClearStore = t => (~cb) => jsClient->Js_.onClearStore(t, ~cb)
+  let onClearStore = (~cb) => jsClient->Js_.onClearStore(~cb)
 
-  let onResetStore = t => (~cb) => jsClient->Js_.onResetStore(t, ~cb)
+  let onResetStore = (~cb) => jsClient->Js_.onResetStore(~cb)
 
   let query = (
     type data variables jsVariables,

--- a/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
+++ b/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
@@ -777,7 +777,7 @@ let make: (
       (),
     )
     ->Js.toOption
-    ->Belt.Option.mapU(safeParse)
+    ->Belt.Option.map(safeParse(_))
   }
 
   let readQuery = (
@@ -811,7 +811,7 @@ let make: (
       ~optimistic,
     )
     ->Js.toOption
-    ->Belt.Option.mapU(safeParse)
+    ->Belt.Option.map(safeParse(_))
   }
 
   let resetStore: unit => Js.Promise.t<
@@ -1015,7 +1015,7 @@ let make: (
         ->Js.Nullable.fromOption,
     )
     ->Js.toOption
-    ->Belt.Option.mapU(safeParse)
+    ->Belt.Option.map(safeParse(_))
   }
 
   let updateFragment = (
@@ -1052,7 +1052,7 @@ let make: (
         ->Js.Nullable.fromOption,
     )
     ->Js.toOption
-    ->Belt.Option.mapU(safeParse)
+    ->Belt.Option.map(safeParse(_))
   }
 
   preserveJsPropsAndContext(

--- a/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
+++ b/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
@@ -54,9 +54,9 @@ module DefaultWatchQueryOptions = {
   }
 
   let make = (~fetchPolicy=?, ~errorPolicy=?, ~context=?, ()) => {
-    fetchPolicy: fetchPolicy,
-    errorPolicy: errorPolicy,
-    context: context,
+    fetchPolicy,
+    errorPolicy,
+    context,
   }
 }
 
@@ -85,9 +85,9 @@ module DefaultQueryOptions = {
   }
 
   let make = (~fetchPolicy=?, ~errorPolicy=?, ~context=?, ()) => {
-    fetchPolicy: fetchPolicy,
-    errorPolicy: errorPolicy,
-    context: context,
+    fetchPolicy,
+    errorPolicy,
+    context,
   }
 }
 
@@ -131,11 +131,11 @@ module DefaultMutateOptions = {
     ~refetchQueries=?,
     (),
   ) => {
-    context: context,
-    fetchPolicy: fetchPolicy,
-    awaitRefetchQueries: awaitRefetchQueries,
-    errorPolicy: errorPolicy,
-    refetchQueries: refetchQueries,
+    context,
+    fetchPolicy,
+    awaitRefetchQueries,
+    errorPolicy,
+    refetchQueries,
   }
 }
 
@@ -171,9 +171,9 @@ module DefaultOptions = {
     ~watchQuery: DefaultWatchQueryOptions.t=?,
     unit,
   ) => t = (~mutate=?, ~query=?, ~watchQuery=?, ()) => {
-    watchQuery: watchQuery,
-    query: query,
-    mutate: mutate,
+    watchQuery,
+    query,
+    mutate,
   }
 }
 
@@ -610,30 +610,30 @@ let make: (
 ) => {
   let jsClient = Js_.make(
     ApolloClientOptions.toJs({
-      uri: uri,
-      credentials: credentials,
-      headers: headers,
-      link: link,
-      cache: cache,
-      ssrForceFetchDelay: ssrForceFetchDelay,
-      ssrMode: ssrMode,
-      connectToDevTools: connectToDevTools,
-      queryDeduplication: queryDeduplication,
-      defaultOptions: defaultOptions,
-      assumeImmutableResults: assumeImmutableResults,
-      resolvers: resolvers,
-      typeDefs: typeDefs,
-      fragmentMatcher: fragmentMatcher,
-      name: name,
-      version: version,
+      uri,
+      credentials,
+      headers,
+      link,
+      cache,
+      ssrForceFetchDelay,
+      ssrMode,
+      connectToDevTools,
+      queryDeduplication,
+      defaultOptions,
+      assumeImmutableResults,
+      resolvers,
+      typeDefs,
+      fragmentMatcher,
+      name,
+      version,
     }),
   )
 
   let clearStore = () =>
     jsClient
     ->Js_.clearStore
-    ->Js.Promise.then_(value => Js.Promise.resolve(Ok(value)), _)
-    ->Js.Promise.catch(e => Js.Promise.resolve(Error(Utils.ensureError(Any(e)))), _)
+    ->(Js.Promise.then_(value => Js.Promise.resolve(Ok(value)), _))
+    ->(Js.Promise.catch(e => Js.Promise.resolve(Error(Utils.ensureError(Any(e)))), _))
 
   let extract = (~optimistic=?, ()) => jsClient->Js_.extract(~optimistic?, ())
 
@@ -661,16 +661,16 @@ let make: (
       jsClient,
       ~options=MutationOptions.toJs(
         {
-          awaitRefetchQueries: awaitRefetchQueries,
-          context: context,
-          errorPolicy: errorPolicy,
-          fetchPolicy: fetchPolicy,
+          awaitRefetchQueries,
+          context,
+          errorPolicy,
+          fetchPolicy,
           mutation: Operation.query,
-          optimisticResponse: optimisticResponse,
-          updateQueries: updateQueries,
-          refetchQueries: refetchQueries,
-          update: update,
-          variables: variables,
+          optimisticResponse,
+          updateQueries,
+          refetchQueries,
+          update,
+          variables,
         },
         ~mapJsVariables,
         ~safeParse,
@@ -678,24 +678,24 @@ let make: (
         ~serializeVariables=Operation.serializeVariables,
       ),
     )
-    ->Js.Promise.then_(
+    ->(Js.Promise.then_(
       jsFetchResult =>
         Js.Promise.resolve(jsFetchResult->FetchResult.fromJs(~safeParse)->FetchResult.toResult),
       _,
-    )
-    ->Js.Promise.catch(error =>
-      Js.Promise.resolve(
-        Error(
-          ApolloError.make(
-            ~networkError=FetchFailure({
-              open Utils
-              ensureError(Any(error))
-            }),
-            (),
+    ))
+    ->(Js.Promise.catch(error =>
+        Js.Promise.resolve(
+          Error(
+            ApolloError.make(
+              ~networkError=FetchFailure({
+                open Utils
+                ensureError(Any(error))
+              }),
+              (),
+            ),
           ),
-        ),
-      )
-    , _)
+        )
+      , _))
   }
 
   let onClearStore = t => (~cb) => jsClient->Js_.onClearStore(t, ~cb)
@@ -721,36 +721,36 @@ let make: (
       jsClient,
       ~options=QueryOptions.toJs(
         {
-          fetchPolicy: fetchPolicy,
+          fetchPolicy,
           query: Operation.query,
-          variables: variables,
-          errorPolicy: errorPolicy,
-          context: context,
+          variables,
+          errorPolicy,
+          context,
         },
         ~mapJsVariables,
         ~serializeVariables=Operation.serializeVariables,
       ),
     )
-    ->Js.Promise.then_(
+    ->(Js.Promise.then_(
       jsApolloQueryResult =>
         Js.Promise.resolve(
           jsApolloQueryResult->ApolloQueryResult.fromJs(~safeParse)->ApolloQueryResult.toResult,
         ),
       _,
-    )
-    ->Js.Promise.catch(error =>
-      Js.Promise.resolve(
-        Error(
-          ApolloError.make(
-            ~networkError=FetchFailure({
-              open Utils
-              ensureError(Any(error))
-            }),
-            (),
+    ))
+    ->(Js.Promise.catch(error =>
+        Js.Promise.resolve(
+          Error(
+            ApolloError.make(
+              ~networkError=FetchFailure({
+                open Utils
+                ensureError(Any(error))
+              }),
+              (),
+            ),
           ),
-        ),
-      )
-    , _)
+        )
+      , _))
   }
 
   let readFragment = (
@@ -767,11 +767,11 @@ let make: (
     jsClient
     ->Js_.readFragment(
       ~options={
-        id: id,
+        id,
         fragment: Fragment.query,
-        fragmentName: fragmentName,
-        optimistic: optimistic,
-        canonizeResults: canonizeResults,
+        fragmentName,
+        optimistic,
+        canonizeResults,
       },
       ~optimistic?,
       (),
@@ -799,11 +799,11 @@ let make: (
       jsClient,
       ~options=DataProxy.ReadQueryOptions.toJs(
         {
-          id: id,
+          id,
           query: Operation.query,
-          variables: variables,
-          optimistic: optimistic,
-          canonizeResults: canonizeResults,
+          variables,
+          optimistic,
+          canonizeResults,
         },
         ~mapJsVariables,
         ~serializeVariables=Operation.serializeVariables,
@@ -819,8 +819,8 @@ let make: (
   > = () =>
     jsClient
     ->Js_.resetStore
-    ->Js.Promise.then_(value => Js.Promise.resolve(Ok(value->Js.toOption)), _)
-    ->Js.Promise.catch(e => Js.Promise.resolve(Error(Utils.ensureError(Any(e)))), _)
+    ->(Js.Promise.then_(value => Js.Promise.resolve(Ok(value->Js.toOption)), _))
+    ->(Js.Promise.catch(e => Js.Promise.resolve(Error(Utils.ensureError(Any(e)))), _))
 
   let restore = (~serializedState) =>
     jsClient->Js_.restore(serializedState)->Js_.Cast.asRescriptCache
@@ -848,11 +848,11 @@ let make: (
       jsClient,
       ~options=SubscriptionOptions.toJs(
         {
-          fetchPolicy: fetchPolicy,
+          fetchPolicy,
           query: Operation.query,
-          variables: variables,
-          errorPolicy: errorPolicy,
-          context: context,
+          variables,
+          errorPolicy,
+          context,
         },
         ~mapJsVariables,
         ~serializeVariables=Operation.serializeVariables,
@@ -904,13 +904,13 @@ let make: (
     ->Js_.watchQuery(
       ~options=WatchQueryOptions.toJs(
         {
-          fetchPolicy: fetchPolicy,
-          nextFetchPolicy: nextFetchPolicy,
+          fetchPolicy,
+          nextFetchPolicy,
           query: Operation.query,
-          variables: variables,
-          errorPolicy: errorPolicy,
-          context: context,
-          pollInterval: pollInterval,
+          variables,
+          errorPolicy,
+          context,
+          pollInterval,
         },
         ~mapJsVariables,
         ~serializeVariables=Operation.serializeVariables,
@@ -932,12 +932,12 @@ let make: (
     jsClient->Js_.writeFragment(
       ~options=DataProxy.WriteFragmentOptions.toJs(
         {
-          broadcast: broadcast,
-          data: data,
-          id: id,
+          broadcast,
+          data,
+          id,
           fragment: Fragment.query,
-          fragmentName: fragmentName,
-          overwrite: overwrite,
+          fragmentName,
+          overwrite,
         },
         ~serialize=Fragment.serialize,
       ),
@@ -960,12 +960,12 @@ let make: (
     jsClient->Js_.writeQuery(
       ~options=DataProxy.WriteQueryOptions.toJs(
         {
-          broadcast: broadcast,
-          data: data,
-          id: id,
+          broadcast,
+          data,
+          id,
           query: Operation.query,
-          variables: variables,
-          overwrite: overwrite,
+          variables,
+          overwrite,
         },
         ~mapJsVariables,
         ~serialize=Operation.serialize,
@@ -992,25 +992,27 @@ let make: (
     let safeParse = Utils.safeParse(Operation.parse)
 
     jsClient
-    ->Js_.updateQuery(~options=DataProxy.UpdateQueryOptions.toJs(
-      {
-        optimistic: optimistic,
-        canonizeResults: canonizeResults,
-        broadcast: broadcast,
-        id: id,
-        query: Operation.query,
-        variables: variables,
-        overwrite: overwrite,
-      },
-      ~mapJsVariables,
-      ~serializeVariables=Operation.serializeVariables,
-    ), ~update=jsData =>
-      jsData
-      ->Js.nullToOption
-      ->Belt.Option.map(Operation.parse)
-      ->update
-      ->Belt.Option.map(Operation.serialize)
-      ->Js.Nullable.fromOption
+    ->Js_.updateQuery(
+      ~options=DataProxy.UpdateQueryOptions.toJs(
+        {
+          optimistic,
+          canonizeResults,
+          broadcast,
+          id,
+          query: Operation.query,
+          variables,
+          overwrite,
+        },
+        ~mapJsVariables,
+        ~serializeVariables=Operation.serializeVariables,
+      ),
+      ~update=jsData =>
+        jsData
+        ->Js.nullToOption
+        ->Belt.Option.map(Operation.parse)
+        ->update
+        ->Belt.Option.map(Operation.serialize)
+        ->Js.Nullable.fromOption,
     )
     ->Js.toOption
     ->Belt.Option.mapU(safeParse)
@@ -1031,21 +1033,23 @@ let make: (
     let safeParse = Utils.safeParse(Fragment.parse)
 
     jsClient
-    ->Js_.updateFragment(~options=DataProxy.UpdateFragmentOptions.toJs({
-      optimistic: optimistic,
-      canonizeResults: canonizeResults,
-      broadcast: broadcast,
-      id: id,
-      fragment: Fragment.query,
-      fragmentName: fragmentName,
-      overwrite: overwrite,
-    }), ~update=jsData =>
-      jsData
-      ->Js.nullToOption
-      ->Belt.Option.map(Fragment.parse)
-      ->update
-      ->Belt.Option.map(Fragment.serialize)
-      ->Js.Nullable.fromOption
+    ->Js_.updateFragment(
+      ~options=DataProxy.UpdateFragmentOptions.toJs({
+        optimistic,
+        canonizeResults,
+        broadcast,
+        id,
+        fragment: Fragment.query,
+        fragmentName,
+        overwrite,
+      }),
+      ~update=jsData =>
+        jsData
+        ->Js.nullToOption
+        ->Belt.Option.map(Fragment.parse)
+        ->update
+        ->Belt.Option.map(Fragment.serialize)
+        ->Js.Nullable.fromOption,
     )
     ->Js.toOption
     ->Belt.Option.mapU(safeParse)
@@ -1054,24 +1058,24 @@ let make: (
   preserveJsPropsAndContext(
     jsClient,
     {
-      clearStore: clearStore,
-      extract: extract,
-      mutate: mutate,
-      onClearStore: onClearStore,
-      onResetStore: onResetStore,
-      query: query,
-      readFragment: readFragment,
-      readQuery: readQuery,
-      resetStore: resetStore,
-      restore: restore,
-      setLink: setLink,
-      stop: stop,
-      subscribe: subscribe,
-      watchQuery: watchQuery,
-      writeFragment: writeFragment,
-      writeQuery: writeQuery,
-      updateQuery: updateQuery,
-      updateFragment: updateFragment,
+      clearStore,
+      extract,
+      mutate,
+      onClearStore,
+      onResetStore,
+      query,
+      readFragment,
+      readQuery,
+      resetStore,
+      restore,
+      setLink,
+      stop,
+      subscribe,
+      watchQuery,
+      writeFragment,
+      writeQuery,
+      updateQuery,
+      updateFragment,
     },
   )
 }

--- a/src/@apollo/client/core/ApolloClient__Core_Types.res
+++ b/src/@apollo/client/core/ApolloClient__Core_Types.res
@@ -170,20 +170,17 @@ module MutationQueryReducersMap = {
     // }> = {
     //     [queryName: string]: MutationQueryReducer<T>;
     // };
-    type t<'jsData> = Js.Dict.t<MutationQueryReducer.Js_.t<'jsData>>
+    type t<'jsData> = RescriptCore.Dict.t<MutationQueryReducer.Js_.t<'jsData>>
   }
 
-  type t<'data> = Js.Dict.t<MutationQueryReducer.t<'data>>
+  type t<'data> = RescriptCore.Dict.t<MutationQueryReducer.t<'data>>
 
   let toJs: (t<'data>, ~safeParse: Types.safeParse<'data, 'jsData>) => Js_.t<'jsData> = (
     t,
     ~safeParse,
   ) =>
-    Js.Dict.map(
-      mutationQueryReducer => (json, options) =>
-        mutationQueryReducer->MutationQueryReducer.toJs(~safeParse, json, options),
-      t,
-    )
+    RescriptCore.Dict.mapValues(t, mutationQueryReducer => (json, options) =>
+      mutationQueryReducer->MutationQueryReducer.toJs(~safeParse, json, options))
 }
 
 module Resolvers = {
@@ -193,7 +190,7 @@ module Resolvers = {
     //         [field: string]: Resolver;
     //     };
     // }
-    type t = Js.Dict.t<Js.Dict.t<Resolver.Js_.t>>
+    type t = RescriptCore.Dict.t<RescriptCore.Dict.t<Resolver.Js_.t>>
   }
   type t = Js_.t
 }

--- a/src/@apollo/client/core/ApolloClient__Core_Types.res
+++ b/src/@apollo/client/core/ApolloClient__Core_Types.res
@@ -82,8 +82,8 @@ module ApolloQueryResult = {
     )
 
     {
-      data: data,
-      error: error,
+      data,
+      error,
       loading: js.loading,
       networkStatus: js.networkStatus->NetworkStatus.fromJs,
     }
@@ -107,7 +107,7 @@ module ApolloQueryResult = {
     switch apolloQueryResult {
     | {data: Some(data)} =>
       Ok({
-        data: data,
+        data,
         error: apolloQueryResult.error,
         loading: apolloQueryResult.loading,
         networkStatus: apolloQueryResult.networkStatus,
@@ -136,7 +136,7 @@ module MutationQueryReducer = {
       queryVariables: Js.Json.t, // ACTUAL: Record<string, any>
     }
 
-    type t<'jsData> = (. Js.Json.t, options<'jsData>) => Js.Json.t
+    type t<'jsData> = (Js.Json.t, options<'jsData>) => Js.Json.t
   }
 
   type options<'data> = {
@@ -150,9 +150,9 @@ module MutationQueryReducer = {
   let toJs: (
     t<'data>,
     ~safeParse: Types.safeParse<'data, 'jsData>,
-    . Js.Json.t,
+    Js.Json.t,
     Js_.options<'jsData>,
-  ) => Js.Json.t = (t, ~safeParse, . previousResult, jsOptions) =>
+  ) => Js.Json.t = (t, ~safeParse, previousResult, jsOptions) =>
     t(
       previousResult,
       {
@@ -180,7 +180,8 @@ module MutationQueryReducersMap = {
     ~safeParse,
   ) =>
     Js.Dict.map(
-      (. mutationQueryReducer) => mutationQueryReducer->MutationQueryReducer.toJs(~safeParse),
+      mutationQueryReducer => (json, options) =>
+        mutationQueryReducer->MutationQueryReducer.toJs(~safeParse, json, options),
       t,
     )
 }

--- a/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.res
+++ b/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.res
@@ -416,12 +416,13 @@ module MutationOptions = {
     errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
     fetchPolicy: t.fetchPolicy->Belt.Option.map(FetchPolicy__noCacheExtracted.toJs),
     mutation: t.mutation,
-    optimisticResponse: t.optimisticResponse->Belt.Option.map((optimisticResponse, variables) =>
-      optimisticResponse(variables)->serialize
-    ),
+    optimisticResponse: t.optimisticResponse->Belt.Option.mapU(optimisticResponse => variables =>
+      optimisticResponse(variables)->serialize),
     refetchQueries: t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
-    update: t.update->Belt.Option.map(MutationUpdaterFn.toJs(~safeParse)),
-    updateQueries: t.updateQueries->Belt.Option.map(MutationQueryReducersMap.toJs(~safeParse)),
+    update: t.update->Belt.Option.mapU(t => MutationUpdaterFn.toJs(t, ~safeParse)),
+    updateQueries: t.updateQueries->Belt.Option.mapU(t =>
+      MutationQueryReducersMap.toJs(t, ~safeParse)
+    ),
     variables: t.variables->serializeVariables->mapJsVariables,
   }
 }

--- a/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.res
+++ b/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.res
@@ -172,7 +172,7 @@ module UpdateQueryFn = {
     //     variables?: TSubscriptionVariables;
     // }) => TData;
     type t<'jsQueryData, 'subscriptionVariables, 'jsSubscriptionData> = (
-      . 'jsQueryData,
+      'jsQueryData,
       t_options<'jsSubscriptionData, 'subscriptionVariables>,
     ) => 'jsQueryData
   }
@@ -198,9 +198,7 @@ module UpdateQueryFn = {
     ~querySafeParse,
     ~querySerialize,
     ~subscriptionSafeParse,
-    . jsQueryData,
-    {subscriptionData: {data}},
-  ) =>
+  ) => (jsQueryData, {subscriptionData: {data}}) =>
     switch (jsQueryData->querySafeParse, data->subscriptionSafeParse) {
     | (Ok(queryData), Ok(subscriptionData)) =>
       t(
@@ -318,7 +316,7 @@ module SubscriptionOptions = {
 
 module MutationUpdaterFn = {
   module Js_ = {
-    type t<'jsData> = (. ApolloCache.t<Js.Json.t>, FetchResult.Js_.t<'jsData>) => unit // Non-Js_ cache is correct here
+    type t<'jsData> = (ApolloCache.t<Js.Json.t>, FetchResult.Js_.t<'jsData>) => unit // Non-Js_ cache is correct here
   }
 
   type t<'data> = (ApolloCache.t<Js.Json.t>, FetchResult.t<'data>) => unit

--- a/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.res
+++ b/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.res
@@ -261,13 +261,14 @@ module SubscribeToMoreOptions = {
   ) => {
     document: t.document,
     variables: t.variables,
-    updateQuery: t.updateQuery->Belt.Option.map(
+    updateQuery: t.updateQuery->Belt.Option.map(updateQueryFn =>
       UpdateQueryFn.toJs(
+        updateQueryFn,
         ~onParseError=onUpdateQueryParseError,
         ~querySafeParse,
         ~querySerialize,
         ~subscriptionSafeParse,
-      ),
+      )
     ),
     onError: t.onError,
     context: t.context,
@@ -324,9 +325,8 @@ module MutationUpdaterFn = {
   let toJs: (t<'data>, ~safeParse: Types.safeParse<'data, 'jsData>) => Js_.t<'jsData> = (
     mutationUpdaterFn,
     ~safeParse,
-    . cache,
-    jsFetchResult,
-  ) => mutationUpdaterFn(cache, jsFetchResult->FetchResult.fromJs(~safeParse))
+  ) => (cache, jsFetchResult) =>
+    mutationUpdaterFn(cache, jsFetchResult->FetchResult.fromJs(~safeParse))
 }
 
 module RefetchQueryDescription = {
@@ -375,7 +375,7 @@ module MutationOptions = {
       // ...extends MutationBaseOption,
       awaitRefetchQueries: option<bool>,
       errorPolicy: option<ErrorPolicy.Js_.t>,
-      optimisticResponse: option<(. 'jsVariables) => 'jsData>,
+      optimisticResponse: option<'jsVariables => 'jsData>,
       update: option<MutationUpdaterFn.Js_.t<'jsData>>,
       updateQueries: option<MutationQueryReducersMap.Js_.t<'jsData>>,
       refetchQueries: option<RefetchQueryDescription.Js_.t>,
@@ -416,7 +416,7 @@ module MutationOptions = {
     errorPolicy: t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
     fetchPolicy: t.fetchPolicy->Belt.Option.map(FetchPolicy__noCacheExtracted.toJs),
     mutation: t.mutation,
-    optimisticResponse: t.optimisticResponse->Belt.Option.map((optimisticResponse, . variables) =>
+    optimisticResponse: t.optimisticResponse->Belt.Option.map((optimisticResponse, variables) =>
       optimisticResponse(variables)->serialize
     ),
     refetchQueries: t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),

--- a/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.res
+++ b/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.res
@@ -118,7 +118,7 @@ module FetchResult = {
       ~graphQLErrors=?js.errors,
       safeParse,
     )
-    {data: data, error: error, extensions: js.extensions, context: js.context}
+    {data, error, extensions: js.extensions, context: js.context}
   }
 
   let fromError: ApolloError.t => t<'data> = error => {
@@ -139,7 +139,7 @@ module FetchResult = {
     switch fetchResult {
     | {data: Some(data)} =>
       Ok({
-        data: data,
+        data,
         error: fetchResult.error,
         extensions: fetchResult.extensions,
         context: fetchResult.context,
@@ -169,7 +169,7 @@ module RequestHandler = {
   module Js_ = {
     // export declare type RequestHandler = (operation: Operation, forward: NextLink) => Observable<FetchResult> | null;
     type t = (
-      . Operation.Js_.t,
+      Operation.Js_.t,
       NextLink.Js_.t,
     ) => Js.Null.t<Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>>
   }
@@ -180,5 +180,5 @@ module RequestHandler = {
     NextLink.Js_.t,
   ) => option<Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>>
 
-  let toJs: t => Js_.t = (t, . operation, forward) => t(operation, forward)->Js.Null.fromOption
+  let toJs: t => Js_.t = t => (operation, forward) => t(operation, forward)->Js.Null.fromOption
 }

--- a/src/@apollo/client/link/retry/ApolloClient__Link_Retry_DelayFunction.res
+++ b/src/@apollo/client/link/retry/ApolloClient__Link_Retry_DelayFunction.res
@@ -10,7 +10,7 @@ module DelayFunction = {
 
   type t = (~count: int, ~operation: Operation.t, ~error: option<Js.Json.t>) => int
 
-  let toJs: t => Js_.t = (t, count, operation, error) =>
+  let toJs: t => Js_.t = t => (count, operation, error) =>
     t(~count, ~operation=operation->Operation.fromJs, ~error)
 }
 

--- a/src/@apollo/client/link/retry/ApolloClient__Link_Retry_RetryFunction.res
+++ b/src/@apollo/client/link/retry/ApolloClient__Link_Retry_RetryFunction.res
@@ -10,7 +10,7 @@ module RetryFunction = {
 
   type t = (~count: int, ~operation: Operation.t, ~error: option<Js.Json.t>) => Js.Promise.t<bool>
 
-  let toJs: t => Js_.t = (t, count, operation, error) =>
+  let toJs: t => Js_.t = t => (count, operation, error) =>
     t(~count, ~operation=operation->Operation.fromJs, ~error)
 }
 

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.res
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.res
@@ -32,7 +32,7 @@ module QueryHookOptions = {
       ~displayName: string=?,
       ~skip: bool=?,
       ~onCompleted: 'jsData => unit=?,
-      ~onError: (. ApolloError.Js_.t) => unit=?,
+      ~onError: ApolloError.Js_.t => unit=?,
       // ..extends BaseQueryOptions
       ~client: ApolloClient.t=?,
       ~context: Js.Json.t=?, // ACTUAL: Record<string, any=?>
@@ -84,12 +84,10 @@ module QueryHookOptions = {
       ~context=?t.context,
       ~displayName=?t.displayName,
       ~errorPolicy=?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-      ~onCompleted=?t.onCompleted->Belt.Option.map((onCompleted, jsData) =>
-        onCompleted(jsData->safeParse)
-      ),
-      ~onError=?t.onError->Belt.Option.map((onError, . jsApolloError) =>
-        onError(ApolloError.fromJs(jsApolloError))
-      ),
+      ~onCompleted=?t.onCompleted->Belt.Option.map(onCompleted => jsData =>
+        onCompleted(jsData->safeParse)),
+      ~onError=?t.onError->Belt.Option.map(onError => jsApolloError =>
+        onError(ApolloError.fromJs(jsApolloError))),
       ~fetchPolicy=?t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
       ~nextFetchPolicy=?t.nextFetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
       ~notifyOnNetworkStatusChange=?t.notifyOnNetworkStatusChange,
@@ -118,7 +116,7 @@ module LazyQueryHookOptions = {
       // ...extends QueryFunctionOptions
       ~displayName: string=?,
       ~onCompleted: 'jsData => unit=?,
-      ~onError: (. ApolloError.Js_.t) => unit=?,
+      ~onError: ApolloError.Js_.t => unit=?,
       // ..extends BaseQueryOptions
       ~client: ApolloClient.t=?,
       ~context: Js.Json.t=?, // ACTUAL: Record<string, any>,
@@ -167,12 +165,10 @@ module LazyQueryHookOptions = {
       ~context=?t.context,
       ~displayName=?t.displayName,
       ~errorPolicy=?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-      ~onCompleted=?t.onCompleted->Belt.Option.map((onCompleted, jsData) =>
-        onCompleted(jsData->safeParse)
-      ),
-      ~onError=?t.onError->Belt.Option.map((onError, . jsApolloError) =>
-        onError(ApolloError.fromJs(jsApolloError))
-      ),
+      ~onCompleted=?t.onCompleted->Belt.Option.map(onCompleted => jsData =>
+        onCompleted(jsData->safeParse)),
+      ~onError=?t.onError->Belt.Option.map(onError => jsApolloError =>
+        onError(ApolloError.fromJs(jsApolloError))),
       ~fetchPolicy=?t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
       ~notifyOnNetworkStatusChange=?t.notifyOnNetworkStatusChange,
       ~query=?t.query,
@@ -221,7 +217,7 @@ module QueryResult = {
       // ...extends FetchMoreOptions
       @optional
       updateQuery: (
-        . 'jsData,
+        'jsData,
         t_fetchMoreOptions_updateQueryOptions<'jsData, 'jsVariables>,
       ) => 'jsData,
     }
@@ -369,7 +365,7 @@ module QueryResult = {
       safeParse,
     )
 
-    let previousData = js.previousData->Belt.Option.map(safeParse)
+    let previousData = js.previousData->Belt.Option.mapU(safeParse)
 
     let fetchMore = (
       ~context=?,
@@ -384,14 +380,13 @@ module QueryResult = {
       ->Js_.fetchMore(
         Js_.t_fetchMoreOptions(
           ~context?,
-          ~updateQuery=?updateQuery->Belt.Option.map((
-            updateQuery,
-            . previousResult,
+          ~updateQuery=?updateQuery->Belt.Option.map(updateQuery => (
+            previousResult,
             jsFetchMoreOptions: Js_.t_fetchMoreOptions_updateQueryOptions<'jsData, 'jsVariables>,
           ) =>
             switch (
               safeParse(previousResult),
-              jsFetchMoreOptions.fetchMoreResult->Belt.Option.map(safeParse),
+              jsFetchMoreOptions.fetchMoreResult->Belt.Option.mapU(safeParse),
             ) {
             | (Ok(previousResult), Some(Ok(fetchMoreResult))) =>
               updateQuery(
@@ -413,13 +408,12 @@ module QueryResult = {
             | (Ok(_), Some(Error(parseError))) =>
               parseErrorDuringCall.contents = Some(Error(parseError))
               previousResult
-            }
-          ),
+            }),
           ~variables=?variables->Belt.Option.map(v => v->serializeVariables->mapJsVariables),
           (),
         ),
       )
-      ->Js.Promise.then_(jsApolloQueryResult =>
+      ->(Js.Promise.then_(jsApolloQueryResult =>
         Js.Promise.resolve(
           switch parseErrorDuringCall.contents {
           | Some(Error(parseError)) =>
@@ -428,38 +422,42 @@ module QueryResult = {
             jsApolloQueryResult->ApolloQueryResult.fromJs(~safeParse)->ApolloQueryResult.toResult
           },
         )
-      , _)
-      ->Js.Promise.catch(error =>
-        Js.Promise.resolve(
-          Error(
-            ApolloError.make(
-              ~networkError=FetchFailure({
-                open Utils
-                ensureError(Any(error))
-              }),
-              (),
+      , _))
+      ->(Js.Promise.catch(error =>
+          Js.Promise.resolve(
+            Error(
+              ApolloError.make(
+                ~networkError=FetchFailure({
+                  open Utils
+                  ensureError(Any(error))
+                }),
+                (),
+              ),
             ),
-          ),
-        )
-      , _)
+          )
+        , _))
     }
 
     let refetch = (~mapJsVariables=Utils.identity, ~variables=?, ()) =>
       js
       ->Js_.refetch(variables->Belt.Option.map(v => v->serializeVariables->mapJsVariables))
-      ->Js.Promise.then_(
+      ->(Js.Promise.then_(
         jsApolloQueryResult =>
           Js.Promise.resolve(
             jsApolloQueryResult->ApolloQueryResult.fromJs(~safeParse)->ApolloQueryResult.toResult,
           ),
         _,
-      )
-      ->Js.Promise.catch(
-        error =>
-          Js.Promise.resolve(
-            Error(ApolloError.make(~networkError=FetchFailure(Utils.ensureError(Any(error))), ())),
-          ),
-        _,
+      ))
+      ->(
+        Js.Promise.catch(
+          error =>
+            Js.Promise.resolve(
+              Error(
+                ApolloError.make(~networkError=FetchFailure(Utils.ensureError(Any(error))), ()),
+              ),
+            ),
+          _,
+        )
       )
 
     let startPolling = pollInterval => js->Js_.startPolling(pollInterval)
@@ -483,12 +481,11 @@ module QueryResult = {
         SubscribeToMoreOptions.toJs(
           {
             document: Operation.query,
-            variables: variables,
-            updateQuery: updateQuery,
-            onError: onError->Belt.Option.map((onError, error) =>
-              onError(SubscriptionError(error))
-            ),
-            context: context,
+            variables,
+            updateQuery,
+            onError: onError->Belt.Option.map(onError => error =>
+              onError(SubscriptionError(error))),
+            context,
           },
           ~onUpdateQueryParseError=parseError =>
             switch onError {
@@ -510,17 +507,17 @@ module QueryResult = {
     {
       called: js.called,
       client: js.client,
-      data: data,
-      previousData: previousData,
-      error: error,
+      data,
+      previousData,
+      error,
       loading: js.loading,
       networkStatus: js.networkStatus->NetworkStatus.fromJs,
-      fetchMore: fetchMore,
-      refetch: refetch,
-      startPolling: startPolling,
-      stopPolling: stopPolling,
-      subscribeToMore: subscribeToMore,
-      updateQuery: updateQuery,
+      fetchMore,
+      refetch,
+      startPolling,
+      stopPolling,
+      subscribeToMore,
+      updateQuery,
     }
   }
 }
@@ -635,16 +632,15 @@ module QueryTuple = {
     ~serializeVariables,
   ) => (
     (~context=?, ~mapJsVariables=ApolloClient__Utils.identity, variables) =>
-      jsExecuteQuery({
-        context: context,
-        variables: variables->serializeVariables->mapJsVariables,
-      }) |> Js.Promise.then_(jsResult =>
-        QueryResult.fromJs(
-          jsResult,
-          ~safeParse,
-          ~serialize,
-          ~serializeVariables,
-        ) |> Js.Promise.resolve
+      Js.Promise.then_(
+        jsResult =>
+          Js.Promise.resolve(
+            QueryResult.fromJs(jsResult, ~safeParse, ~serialize, ~serializeVariables),
+          ),
+        jsExecuteQuery({
+          context,
+          variables: variables->serializeVariables->mapJsVariables,
+        }),
       ),
     jsLazyQueryResult->LazyQueryResult.fromJs(~safeParse, ~serialize, ~serializeVariables),
   )
@@ -679,16 +675,15 @@ module QueryTuple__noVariables = {
     ~variables,
   ) => (
     (~context=?, ()) =>
-      jsExecuteQuery({
-        context: context,
-        variables: variables->serializeVariables->mapJsVariables,
-      }) |> Js.Promise.then_(jsResult =>
-        QueryResult.fromJs(
-          jsResult,
-          ~safeParse,
-          ~serialize,
-          ~serializeVariables,
-        ) |> Js.Promise.resolve
+      Js.Promise.then_(
+        jsResult =>
+          Js.Promise.resolve(
+            QueryResult.fromJs(jsResult, ~safeParse, ~serialize, ~serializeVariables),
+          ),
+        jsExecuteQuery({
+          context,
+          variables: variables->serializeVariables->mapJsVariables,
+        }),
       ),
     jsLazyQueryResult->LazyQueryResult.fromJs(~safeParse, ~serialize, ~serializeVariables),
   )
@@ -764,7 +759,7 @@ module MutationHookOptions = {
       ~fetchPolicy: FetchPolicy__noCacheExtracted.Js_.t=?,
       ~ignoreResults: bool=?,
       ~notifyOnNetworkStatusChange: bool=?,
-      ~onError: (. ApolloError.Js_.t) => unit=?,
+      ~onError: ApolloError.Js_.t => unit=?,
       ~onCompleted: 'jsData => unit=?,
       ~optimisticResponse: 'jsVariables => 'jsData=?,
       ~refetchQueries: RefetchQueryDescription.Js_.t=?,
@@ -813,17 +808,14 @@ module MutationHookOptions = {
       ~ignoreResults=?t.ignoreResults,
       ~mutation=?t.mutation,
       ~notifyOnNetworkStatusChange=?t.notifyOnNetworkStatusChange,
-      ~onError=?t.onError->Belt.Option.map((onError, . jsApolloError) =>
-        onError(ApolloError.fromJs(jsApolloError))
-      ),
-      ~onCompleted=?t.onCompleted->Belt.Option.map((onCompleted, jsData) =>
-        onCompleted(jsData->safeParse)
-      ),
-      ~optimisticResponse=?t.optimisticResponse->Belt.Option.map((optimisticResponse, variables) =>
-        optimisticResponse(variables)->serialize
-      ),
+      ~onError=?t.onError->Belt.Option.map(onError => jsApolloError =>
+        onError(ApolloError.fromJs(jsApolloError))),
+      ~onCompleted=?t.onCompleted->Belt.Option.map(onCompleted => jsData =>
+        onCompleted(jsData->safeParse)),
+      ~optimisticResponse=?t.optimisticResponse->Belt.Option.map(optimisticResponse => variables =>
+        optimisticResponse(variables)->serialize),
       ~refetchQueries=?t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
-      ~update=?t.update->Belt.Option.map(MutationUpdaterFn.toJs(~safeParse)),
+      ~update=?t.update->Belt.Option.map(updater => MutationUpdaterFn.toJs(updater, ~safeParse)),
       ~variables=?t.variables->Belt.Option.map(v => v->serializeVariables->mapJsVariables),
       (),
     )
@@ -868,8 +860,8 @@ module MutationResult = {
       safeParse,
     )
     {
-      data: data,
-      error: error,
+      data,
+      error,
       loading: js.loading,
       called: js.called,
       client: js.client,
@@ -892,7 +884,7 @@ module MutationFunctionOptions = {
     type t<'jsData, 'jsVariables> = {
       // We don't allow optional variables because it's not typesafe
       variables: 'jsVariables,
-      optimisticResponse: option<(. 'jsVariables) => 'jsData>,
+      optimisticResponse: option<'jsVariables => 'jsData>,
       refetchQueries: option<RefetchQueryDescription.Js_.t>,
       awaitRefetchQueries: option<bool>,
       update: option<MutationUpdaterFn.Js_.t<'jsData>>,
@@ -925,12 +917,11 @@ module MutationFunctionOptions = {
     ~serializeVariables,
   ) => {
     variables: t.variables->serializeVariables->mapJsVariables,
-    optimisticResponse: t.optimisticResponse->Belt.Option.map((optimisticResponse, . variables) =>
-      optimisticResponse(variables)->serialize
-    ),
+    optimisticResponse: t.optimisticResponse->Belt.Option.map(optimisticResponse => variables =>
+      optimisticResponse(variables)->serialize),
     refetchQueries: t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
     awaitRefetchQueries: t.awaitRefetchQueries,
-    update: t.update->Belt.Option.map(MutationUpdaterFn.toJs(~safeParse)),
+    update: t.update->Belt.Option.map(updateFn => MutationUpdaterFn.toJs(updateFn, ~safeParse)),
     context: t.context,
     fetchPolicy: t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
   }
@@ -988,13 +979,13 @@ module MutationTuple = {
         Some(
           MutationFunctionOptions.toJs(
             {
-              variables: variables,
-              optimisticResponse: optimisticResponse,
-              refetchQueries: refetchQueries,
-              awaitRefetchQueries: awaitRefetchQueries,
-              update: update,
-              context: context,
-              fetchPolicy: fetchPolicy,
+              variables,
+              optimisticResponse,
+              refetchQueries,
+              awaitRefetchQueries,
+              update,
+              context,
+              fetchPolicy,
             },
             ~mapJsVariables,
             ~safeParse,
@@ -1003,17 +994,21 @@ module MutationTuple = {
           ),
         ),
       )
-      ->Js.Promise.then_(
+      ->(Js.Promise.then_(
         jsFetchResult =>
           Js.Promise.resolve(FetchResult.fromJs(jsFetchResult, ~safeParse)->FetchResult.toResult),
         _,
-      )
-      ->Js.Promise.catch(
-        error =>
-          Js.Promise.resolve(
-            Error(ApolloError.make(~networkError=FetchFailure(Utils.ensureError(Any(error))), ())),
-          ),
-        _,
+      ))
+      ->(
+        Js.Promise.catch(
+          error =>
+            Js.Promise.resolve(
+              Error(
+                ApolloError.make(~networkError=FetchFailure(Utils.ensureError(Any(error))), ()),
+              ),
+            ),
+          _,
+        )
       )
 
     (mutationFn, jsMutationResult->MutationResult.fromJs(~safeParse))
@@ -1065,13 +1060,13 @@ module MutationTuple__noVariables = {
         Some(
           MutationFunctionOptions.toJs(
             {
-              variables: variables,
-              optimisticResponse: optimisticResponse,
-              refetchQueries: refetchQueries,
-              awaitRefetchQueries: awaitRefetchQueries,
-              update: update,
-              context: context,
-              fetchPolicy: fetchPolicy,
+              variables,
+              optimisticResponse,
+              refetchQueries,
+              awaitRefetchQueries,
+              update,
+              context,
+              fetchPolicy,
             },
             ~mapJsVariables,
             ~safeParse,
@@ -1080,17 +1075,21 @@ module MutationTuple__noVariables = {
           ),
         ),
       )
-      ->Js.Promise.then_(
+      ->(Js.Promise.then_(
         jsFetchResult =>
           Js.Promise.resolve(FetchResult.fromJs(jsFetchResult, ~safeParse)->FetchResult.toResult),
         _,
-      )
-      ->Js.Promise.catch(
-        error =>
-          Js.Promise.resolve(
-            Error(ApolloError.make(~networkError=FetchFailure(Utils.ensureError(Any(error))), ())),
-          ),
-        _,
+      ))
+      ->(
+        Js.Promise.catch(
+          error =>
+            Js.Promise.resolve(
+              Error(
+                ApolloError.make(~networkError=FetchFailure(Utils.ensureError(Any(error))), ()),
+              ),
+            ),
+          _,
+        )
       )
 
     (mutationFn, jsMutationResult->MutationResult.fromJs(~safeParse))
@@ -1127,7 +1126,7 @@ module SubscriptionResult = {
       safeParse,
     )
 
-    {loading: js.loading, data: data, error: error}
+    {loading: js.loading, data, error}
   }
 }
 
@@ -1171,10 +1170,10 @@ module BaseSubscriptionOptions = {
     type rec t<'jsData, 'jsVariables> = {
       variables: option<'jsVariables>,
       fetchPolicy: option<FetchPolicy.t>,
-      shouldResubscribe: option<(. t<'jsData, 'jsVariables>) => bool>,
+      shouldResubscribe: option<t<'jsData, 'jsVariables> => bool>,
       client: option<ApolloClient.t>,
       skip: option<bool>,
-      onSubscriptionData: option<(. OnSubscriptionDataOptions.Js_.t<'jsData>) => unit>,
+      onSubscriptionData: option<OnSubscriptionDataOptions.Js_.t<'jsData> => unit>,
       onSubscriptionComplete: option<unit => unit>,
     }
   }
@@ -1217,10 +1216,10 @@ module SubscriptionHookOptions = {
       // Intentionally restricted to not be non-optional. `option(unit)` does not compile cleanly to `undefined`
       ~variables: 'jsVariables,
       ~fetchPolicy: FetchPolicy.t=?,
-      ~shouldResubscribe: (. BaseSubscriptionOptions.Js_.t<'jsData, 'jsVariables>) => bool=?,
+      ~shouldResubscribe: BaseSubscriptionOptions.Js_.t<'jsData, 'jsVariables> => bool=?,
       ~client: ApolloClient.t=?,
       ~skip: bool=?,
-      ~onSubscriptionData: (. OnSubscriptionDataOptions.Js_.t<'jsData>) => unit=?,
+      ~onSubscriptionData: OnSubscriptionDataOptions.Js_.t<'jsData> => unit=?,
       ~onSubscriptionComplete: unit => unit=?,
       unit,
     ) => t<'jsData, 'jsVariables> = ""
@@ -1247,19 +1246,17 @@ module SubscriptionHookOptions = {
       ~subscription=?t.subscription,
       ~variables=t.variables->serializeVariables->mapJsVariables,
       ~fetchPolicy=?t.fetchPolicy,
-      ~shouldResubscribe=?t.shouldResubscribe->Belt.Option.map((
-        shouldResubscribe,
-        . jsBaseSubscriptionOptions,
-      ) => shouldResubscribe(jsBaseSubscriptionOptions->BaseSubscriptionOptions.fromJs)),
+      ~shouldResubscribe=?t.shouldResubscribe->Belt.Option.map(
+        shouldResubscribe => jsBaseSubscriptionOptions =>
+          shouldResubscribe(jsBaseSubscriptionOptions->BaseSubscriptionOptions.fromJs),
+      ),
       ~client=?t.client,
       ~skip=?t.skip,
-      ~onSubscriptionData=?t.onSubscriptionData->Belt.Option.map((
-        onSubscriptionData,
-        . jsOnSubscriptionDataOptions,
-      ) =>
-        onSubscriptionData(
-          jsOnSubscriptionDataOptions->OnSubscriptionDataOptions.fromJs(~safeParse),
-        )
+      ~onSubscriptionData=?t.onSubscriptionData->Belt.Option.map(
+        onSubscriptionData => jsOnSubscriptionDataOptions =>
+          onSubscriptionData(
+            jsOnSubscriptionDataOptions->OnSubscriptionDataOptions.fromJs(~safeParse),
+          ),
       ),
       ~onSubscriptionComplete=?t.onSubscriptionComplete,
       (),

--- a/src/@apollo/client/react/types/ApolloClient__React_Types.res
+++ b/src/@apollo/client/react/types/ApolloClient__React_Types.res
@@ -365,7 +365,7 @@ module QueryResult = {
       safeParse,
     )
 
-    let previousData = js.previousData->Belt.Option.mapU(safeParse)
+    let previousData = js.previousData->Belt.Option.map(safeParse(_))
 
     let fetchMore = (
       ~context=?,
@@ -386,7 +386,7 @@ module QueryResult = {
           ) =>
             switch (
               safeParse(previousResult),
-              jsFetchMoreOptions.fetchMoreResult->Belt.Option.mapU(safeParse),
+              jsFetchMoreOptions.fetchMoreResult->Belt.Option.map(safeParse(_)),
             ) {
             | (Ok(previousResult), Some(Ok(fetchMoreResult))) =>
               updateQuery(

--- a/src/@apollo/client/utilities/graphql/ApolloClient__Utilities_Graphql_Fragments.res
+++ b/src/@apollo/client/utilities/graphql/ApolloClient__Utilities_Graphql_Fragments.res
@@ -2,7 +2,7 @@ module FragmentDefinitionNode = ApolloClient__Graphql.Language.Ast.FragmentDefin
 
 module FragmentMap = {
   module Js_ = {
-    type t = Js.Dict.t<FragmentDefinitionNode.t>
+    type t = RescriptCore.Dict.t<FragmentDefinitionNode.t>
   }
 
   type t = Js_.t

--- a/src/ApolloClient__Utils.res
+++ b/src/ApolloClient__Utils.res
@@ -8,10 +8,10 @@ let ensureError = ApolloError.ensureError
 
 external asJson: 'any => Js.Json.t = "%identity"
 
-let safeParse: ('jsData => 'data) => Types.safeParse<'data, 'jsData> = (parse, jsData) =>
+let safeParse: ('jsData => 'data) => Types.safeParse<'data, 'jsData> = parse => jsData =>
   switch parse(jsData) {
   | data => Ok(data)
-  | exception Js.Exn.Error(error) => Error({value: jsData->asJson, error: error})
+  | exception Js.Exn.Error(error) => Error({value: jsData->asJson, error})
   }
 
 let safeParseAndLiftToCommonResultProps: (

--- a/src/ApolloClient__Utils.res
+++ b/src/ApolloClient__Utils.res
@@ -31,7 +31,7 @@ let safeParseAndLiftToCommonResultProps: (
   | (None, None) => None
   }
 
-  switch jsData->Belt.Option.map(jsData => safeParse(jsData)) {
+  switch jsData->Belt.Option.map(safeParse(_)) {
   | Some(Error(parseError)) =>
     // Be careful we do not overwrite an existing error with a ParseError
     existingError->Belt.Option.isSome

--- a/src/graphql/error/ApolloClient__Graphql_Error_GraphQLError.res
+++ b/src/graphql/error/ApolloClient__Graphql_Error_GraphQLError.res
@@ -31,5 +31,5 @@ type t = {
   source: option<Source.t>,
   position: option<array<int>>,
   originalError: Js.nullable<Js.Exn.t>,
-  extensions: option<Js.Dict.t<Js.Json.t>>,
+  extensions: option<RescriptCore.Dict.t<Js.Json.t>>,
 }


### PR DESCRIPTION
## Purpose

To allow pre-Rescript v11 projects to use this library without reconfiguring ppx flags or setting `"uncurried": false` in one's `rescript.json` (previously the now deprecated `bsconfig.json`).

## Background

This exists as a subsequent step following an intermediate config-only solution wherein this library temporarily supports the `"uncurried": false` flag to quickly get this working with Rescript ≥ 11.

## Caveats

This required the installation of `@rescript/core`, a new library that deprecates the old `Js` library that shipped with Rescript originally. Though this libary is an explicit install now, it will be folded into the Rescript ecosystem and shipped out in later releases.

For now, this was added to avoid a strange error wherein `Js.Dict.map` relied on a curried implementation.
In contrast, `RescriptCore.Dict.mapValues` does not.

This will need some testing against the EXAMPLES since it is not working correctly but I've done some preliminary testing against an external project of mine and appears to compile correctly.