### PR TITLE
Uncurries internals for rescript 11 compatibility

### DIFF
--- a/EXAMPLES/bsconfig.json
+++ b/EXAMPLES/bsconfig.json
@@ -1,7 +1,9 @@
 {
   "name": "examples",
+  "uncurried": false,
   "graphql": {
     "apolloMode": true,
+    "uncurried": false,
     "extendMutation": "ApolloClient.GraphQL_PPX.ExtendMutation",
     "extendQuery": "ApolloClient.GraphQL_PPX.ExtendQuery",
     "extendSubscription": "ApolloClient.GraphQL_PPX.ExtendSubscription",

--- a/EXAMPLES/package.json
+++ b/EXAMPLES/package.json
@@ -11,10 +11,10 @@
     "start": "rescript build -with-deps -w"
   },
   "devDependencies": {
-    "@reasonml-community/graphql-ppx": "1.2.4-1345e061.0",
+    "@reasonml-community/graphql-ppx": "1.2.4-79d140a5.0",
     "graphql-client-example-server": "1.5.2",
     "html-webpack-plugin": "5.5.0",
-    "rescript": "10.1.2",
+    "rescript": "11.1.4",
     "webpack": "5.75.0",
     "webpack-cli": "5.0.1",
     "webpack-dev-server": "^4.11.1"
@@ -26,7 +26,7 @@
     "graphql": "^15.7.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "rescript-apollo-client": "3.2.0",
+    "rescript-apollo-client": "*",
     "subscriptions-transport-ws": "0.11.0"
   }
 }

--- a/EXAMPLES/src/Apollo.res
+++ b/EXAMPLES/src/Apollo.res
@@ -8,6 +8,12 @@ let httpLink = ApolloClient.Link.HttpLink.make(
   (),
 )
 
+let _retryLink = ApolloClient.Link.RetryLink.make(
+  ~attempts=RetryFunction(async (~count, ~operation as _, ~error as _) => count < 3),
+  ~delay=DelayFunction((~count as _, ~operation as _, ~error as _) => 1_000),
+  (),
+)
+
 let wsLink = {
   open ApolloClient.Link.WebSocketLink
   make(
@@ -42,3 +48,14 @@ let client = {
     (),
   )
 }
+
+client.onClearStore(~cb=async () => {
+  Js.log("store cleared")
+})
+
+client.onResetStore(~cb=async () => {
+  Js.log("store reset")
+})
+
+let _ = client.clearStore()
+let _ = client.resetStore()

--- a/EXAMPLES/src/WebpackEntry.res
+++ b/EXAMPLES/src/WebpackEntry.res
@@ -1,3 +1,4 @@
+@@warning("-3")
 switch ReactDOM.querySelector("#root") {
 | Some(el) =>
   ReactDOM.render(

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,6 @@
 {
   "name": "rescript-apollo-client",
+  "uncurried": false,
   "package-specs": [
     {
       "module": "commonjs",

--- a/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.res
+++ b/src/@apollo/client/cache/core/ApolloClient__Cache_Core_Cache.res
@@ -181,7 +181,7 @@ module ApolloCache = {
       ~fragmentName=?,
       (),
     ) => {
-      let safeParse = Utils.safeParse(Fragment.parse)
+      let safeParse = Utils.safeParse(. Fragment.parse)
 
       js
       ->Js_.readFragment(
@@ -196,7 +196,7 @@ module ApolloCache = {
         (),
       )
       ->Js.toOption
-      ->Belt.Option.map(safeParse)
+      ->Belt.Option.mapU(safeParse)
     }
 
     let readQuery = (
@@ -212,7 +212,7 @@ module ApolloCache = {
       ~canonizeResults=?,
       variables,
     ) => {
-      let safeParse = Utils.safeParse(Operation.parse)
+      let safeParse = Utils.safeParse(. Operation.parse)
 
       js
       ->Js_.readQuery(
@@ -230,7 +230,7 @@ module ApolloCache = {
         ~optimistic,
       )
       ->Js.toOption
-      ->Belt.Option.map(safeParse)
+      ->Belt.Option.mapU(safeParse)
     }
 
     let writeFragment = (
@@ -304,7 +304,7 @@ module ApolloCache = {
       ~update,
       variables,
     ) => {
-      let safeParse = Utils.safeParse(Operation.parse)
+      let safeParse = Utils.safeParse(. Operation.parse)
 
       js
       ->Js_.updateQuery(
@@ -330,7 +330,7 @@ module ApolloCache = {
           ->Js.Nullable.fromOption,
       )
       ->Js.toOption
-      ->Belt.Option.map(safeParse)
+      ->Belt.Option.mapU(safeParse)
     }
 
     let updateFragment = (
@@ -345,7 +345,7 @@ module ApolloCache = {
       ~update,
       (),
     ) => {
-      let safeParse = Utils.safeParse(Fragment.parse)
+      let safeParse = Utils.safeParse(. Fragment.parse)
 
       js
       ->Js_.updateFragment(
@@ -367,7 +367,7 @@ module ApolloCache = {
           ->Js.Nullable.fromOption,
       )
       ->Js.toOption
-      ->Belt.Option.map(safeParse)
+      ->Belt.Option.mapU(safeParse)
     }
 
     preserveJsPropsAndContext(

--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_InMemoryCache.res
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_InMemoryCache.res
@@ -85,5 +85,5 @@ let make: (
     ?dataIdFromObject,
     ?possibleTypes,
     ?resultCaching,
-    typePolicies: ?typePolicies->Belt.Option.map(TypePolicies.toJs),
+    typePolicies: ?typePolicies->Belt.Option.mapU(TypePolicies.toJs),
   })->ApolloCache.fromJs

--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies.res
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies.res
@@ -78,14 +78,14 @@ module TypePolicy = {
     fields?: t_fields,
   }
 
-  let toJs: t => Js_.t = t => {
-    keyFields: ?t.keyFields->Belt.Option.map(KeyArgs.toJs),
+  let toJs: (. t) => Js_.t = (. t) => {
+    keyFields: ?t.keyFields->Belt.Option.mapU(KeyArgs.toJs),
     queryType: ?t.queryType,
     mutationType: ?t.mutationType,
     subscriptionType: ?t.subscriptionType,
-    fields: ?t.fields->Belt.Option.map(fields =>
+    fields: ?t.fields->Belt.Option.mapU((. fields) =>
       fields
-      ->Belt.Array.map(((fieldKey, t_field)) => (
+      ->Belt.Array.mapU((. (fieldKey, t_field)) => (
         fieldKey,
         switch t_field {
         | ConcatPagination(keyArgs) =>
@@ -97,7 +97,7 @@ module TypePolicy = {
 
         | FieldPolicy(fieldPolicy) => fieldPolicy->FieldPolicy.toJs->Js_.FieldsUnion.fieldPolicy
         | FieldReadFunction(fieldReadFunction) =>
-          fieldReadFunction->FieldReadFunction.toJs->Js_.FieldsUnion.fieldReadFunction
+          FieldReadFunction.toJs(. fieldReadFunction)->Js_.FieldsUnion.fieldReadFunction
         },
       ))
       ->Js.Dict.fromArray
@@ -133,8 +133,8 @@ module TypePolicies = {
 
   type t = array<(typename, TypePolicy.t)>
 
-  let toJs: t => Js_.t = t =>
-    t->Belt.Array.map(((key, policy)) => (key, TypePolicy.toJs(policy)))->Js.Dict.fromArray
+  let toJs: (. t) => Js_.t = (. t) =>
+    t->Belt.Array.mapU((. (key, policy)) => (key, TypePolicy.toJs(. policy)))->Js.Dict.fromArray
 }
 
 module PossibleTypesMap = {

--- a/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies_FieldPolicy.res
+++ b/src/@apollo/client/cache/inmemory/ApolloClient__Cache_InMemory_Policies_FieldPolicy.res
@@ -100,11 +100,12 @@ module FieldMergeFunction = {
     //    incoming: SafeReadonly<TIncoming>,
     //    options: TOptions,
     //  ) => SafeReadonly<TExisting>;
-    type t<'existing> = ('existing, 'existing, FieldFunctionOptions.Js_.t) => 'existing
+    type t<'existing> = (. 'existing, 'existing, FieldFunctionOptions.Js_.t) => 'existing
   }
 
-  let toJs: t<'existing> => Js_.t<'existing> = (t, existing, incoming, jsFieldFunctionOptions) =>
-    t(existing, incoming, jsFieldFunctionOptions->FieldFunctionOptions.fromJs)
+  let toJs: (. t<'existing>) => Js_.t<'existing> = (. t) =>
+    (. existing, incoming, jsFieldFunctionOptions) =>
+      t(existing, incoming, jsFieldFunctionOptions->FieldFunctionOptions.fromJs)
 }
 
 module FieldMerge = {
@@ -116,22 +117,22 @@ module FieldMerge = {
     // FieldMergeFunction<TExisting, TIncoming, TOptions> | boolean;
     module FieldMergeUnion: {
       type t<'existing>
-      let mergeFunction: FieldMergeFunction.Js_.t<'existing> => t<'existing>
+      let mergeFunction: (. FieldMergeFunction.Js_.t<'existing>) => t<'existing>
       let true_: t<'existing>
     } = {
       @unboxed
       type rec t<'existing> = Any('a): t<'existing>
-      let mergeFunction = (v: FieldMergeFunction.Js_.t<'existing>) => Any(v)
+      let mergeFunction = (. v: FieldMergeFunction.Js_.t<'existing>) => Any(v)
       let true_ = Any(true)
     }
 
     type t<'existing> = FieldMergeUnion.t<'existing>
   }
 
-  let toJs: t<'existing> => Js_.t<'existing> = x =>
+  let toJs: (. t<'existing>) => Js_.t<'existing> = (. x) =>
     switch x {
     | MergeFunction(mergeFunction) =>
-      mergeFunction->FieldMergeFunction.toJs->Js_.FieldMergeUnion.mergeFunction
+      Js_.FieldMergeUnion.mergeFunction(. FieldMergeFunction.toJs(. mergeFunction))
     | True => Js_.FieldMergeUnion.true_
     }
 }
@@ -141,11 +142,12 @@ module FieldReadFunction = {
 
   module Js_ = {
     // export declare type FieldReadFunction<TExisting = any, TReadResult = TExisting> = (existing: SafeReadonly<TExisting> | undefined, options: FieldFunctionOptions) => TReadResult | undefined;
-    type t<'existing> = (option<'existing>, FieldFunctionOptions.Js_.t) => 'existing
+    type t<'existing> = (. option<'existing>, FieldFunctionOptions.Js_.t) => 'existing
   }
 
-  let toJs: t<'existing> => Js_.t<'existing> = (t, existing, jsFieldFunctionOptions) =>
-    t(existing, jsFieldFunctionOptions->FieldFunctionOptions.fromJs)
+  let toJs: (. t<'existing>) => Js_.t<'existing> = (. t) =>
+    (. existing, jsFieldFunctionOptions) =>
+      t(existing, jsFieldFunctionOptions->FieldFunctionOptions.fromJs)
 }
 
 module KeySpecifier = {
@@ -200,7 +202,7 @@ module FieldPolicy_KeyArgs = {
     type t = KeyArgsUnion.t
   }
 
-  let toJs: t => Js_.t = x =>
+  let toJs: (. t) => Js_.t = (. x) =>
     switch x {
     | KeySpecifier(keySpecifier) => keySpecifier->Js_.KeyArgsUnion.keySpecifier
     | KeyArgsFunction(keyArgsFunction) => keyArgsFunction->Js_.KeyArgsUnion.keyArgsFunction
@@ -229,8 +231,8 @@ module FieldPolicy = {
   }
 
   let toJs: t<'existing> => Js_.t<'existing> = t => {
-    keyArgs: ?t.keyArgs->Belt.Option.map(FieldPolicy_KeyArgs.toJs),
-    read: ?t.read->Belt.Option.map(FieldReadFunction.toJs),
-    merge: ?t.merge->Belt.Option.map(FieldMerge.toJs),
+    keyArgs: ?t.keyArgs->Belt.Option.mapU(FieldPolicy_KeyArgs.toJs),
+    read: ?t.read->Belt.Option.mapU(FieldReadFunction.toJs),
+    merge: ?t.merge->Belt.Option.mapU(FieldMerge.toJs),
   }
 }

--- a/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
+++ b/src/@apollo/client/core/ApolloClient__Core_ApolloClient.res
@@ -47,9 +47,9 @@ module DefaultWatchQueryOptions = {
     context?: Js.Json.t,
   }
 
-  let toJs: t => Js_.t = t => {
-    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
-    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+  let toJs: (. t) => Js_.t = (. t) => {
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.mapU(WatchQueryFetchPolicy.toJs),
+    errorPolicy: ?t.errorPolicy->Belt.Option.mapU(ErrorPolicy.toJs),
     context: ?t.context,
   }
 
@@ -79,13 +79,13 @@ module DefaultQueryOptions = {
     context?: Js.Json.t,
   }
 
-  let toJs: t => Js_.t = t => {
+  let toJs: (. t) => Js_.t = (. t) => {
     fetchPolicy: ?switch t.fetchPolicy {
-    | Some(fetchPolicy) => FetchPolicy.toJs(fetchPolicy)->Some
+    | Some(fetchPolicy) => FetchPolicy.toJs(. fetchPolicy)->Some
     | None => None
     },
     errorPolicy: ?switch t.errorPolicy {
-    | Some(errorPolicy) => ErrorPolicy.toJs(errorPolicy)->Some
+    | Some(errorPolicy) => ErrorPolicy.toJs(. errorPolicy)->Some
     | None => None
     },
     context: ?t.context,
@@ -123,12 +123,12 @@ module DefaultMutateOptions = {
     refetchQueries?: RefetchQueryDescription.t,
   }
 
-  let toJs: t => Js_.t = t => {
+  let toJs: (. t) => Js_.t = (. t) => {
     context: ?t.context,
-    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(FetchPolicy__noCacheExtracted.toJs),
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.mapU(FetchPolicy__noCacheExtracted.toJs),
     awaitRefetchQueries: ?t.awaitRefetchQueries,
-    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-    refetchQueries: ?t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
+    errorPolicy: ?t.errorPolicy->Belt.Option.mapU(ErrorPolicy.toJs),
+    refetchQueries: ?t.refetchQueries->Belt.Option.mapU(RefetchQueryDescription.toJs),
   }
 
   @deprecated("Just construct instead")
@@ -168,10 +168,10 @@ module DefaultOptions = {
     mutate?: DefaultMutateOptions.t,
   }
 
-  let toJs: t => Js_.t = t => {
-    watchQuery: ?t.watchQuery->Belt.Option.map(DefaultWatchQueryOptions.toJs),
-    query: ?t.query->Belt.Option.map(DefaultQueryOptions.toJs),
-    mutate: ?t.mutate->Belt.Option.map(DefaultMutateOptions.toJs),
+  let toJs: (. t) => Js_.t = (. t) => {
+    watchQuery: ?t.watchQuery->Belt.Option.mapU(DefaultWatchQueryOptions.toJs),
+    query: ?t.query->Belt.Option.mapU(DefaultQueryOptions.toJs),
+    mutate: ?t.mutate->Belt.Option.mapU(DefaultMutateOptions.toJs),
   }
 
   @deprecated("Just construct instead")
@@ -256,7 +256,7 @@ module ApolloClientOptions = {
     ssrMode: ?t.ssrMode,
     connectToDevTools: ?t.connectToDevTools,
     queryDeduplication: ?t.queryDeduplication,
-    defaultOptions: ?t.defaultOptions->Belt.Option.map(DefaultOptions.toJs),
+    defaultOptions: ?t.defaultOptions->Belt.Option.mapU(DefaultOptions.toJs),
     assumeImmutableResults: ?t.assumeImmutableResults,
     resolvers: ?t.resolvers,
     typeDefs: ?t.typeDefs,
@@ -328,11 +328,11 @@ module Js_ = {
 
   // onClearStore(cb: () => Promise<any>): () => void;
   @send
-  external onClearStore: (t, ~cb: unit => Js.Promise.t<unit>, unit) => unit = "onClearStore"
+  external onClearStore: (t, ~cb: unit => Js.Promise.t<unit>) => unit = "onClearStore"
 
   // onResetStore(cb: () => Promise<any>): () => void;
   @send
-  external onResetStore: (t, ~cb: unit => Js.Promise.t<unit>, unit) => unit = "onResetStore"
+  external onResetStore: (t, ~cb: unit => Js.Promise.t<unit>) => unit = "onResetStore"
 
   // query<T = any, TVariables = OperationVariables>(options: QueryOptions<TVariables>): Promise<ApolloQueryResult<T>>;
   @send
@@ -446,9 +446,9 @@ type t = {
     'variables,
   ) => Js.Promise.t<Belt.Result.t<FetchResult.t__ok<'data>, ApolloError.t>>,
   @as("rescript_onClearStore")
-  onClearStore: (~cb: unit => Js.Promise.t<unit>, unit) => unit,
+  onClearStore: (~cb: unit => Js.Promise.t<unit>) => unit,
   @as("rescript_onResetStore")
-  onResetStore: (~cb: unit => Js.Promise.t<unit>, unit) => unit,
+  onResetStore: (~cb: unit => Js.Promise.t<unit>) => unit,
   @as("rescript_query")
   query: 'data 'variables 'jsVariables. (
     ~query: module(Operation with
@@ -665,7 +665,7 @@ let make: (
     ~update=?,
     variables,
   ) => {
-    let safeParse = Utils.safeParse(Operation.parse)
+    let safeParse = Utils.safeParse(. Operation.parse)
 
     Js_.mutate(
       jsClient,
@@ -725,7 +725,7 @@ let make: (
     ~mapJsVariables=Utils.identity,
     variables,
   ) => {
-    let safeParse = Utils.safeParse(Operation.parse)
+    let safeParse = Utils.safeParse(. Operation.parse)
 
     Js_.query(
       jsClient,
@@ -772,7 +772,7 @@ let make: (
     ~fragmentName=?,
     (),
   ) => {
-    let safeParse = Utils.safeParse(Fragment.parse)
+    let safeParse = Utils.safeParse(. Fragment.parse)
 
     jsClient
     ->Js_.readFragment(
@@ -787,7 +787,7 @@ let make: (
       (),
     )
     ->Js.toOption
-    ->Belt.Option.map(safeParse)
+    ->Belt.Option.mapU(safeParse)
   }
 
   let readQuery = (
@@ -803,7 +803,7 @@ let make: (
     ~canonizeResults=?,
     variables,
   ) => {
-    let safeParse = Utils.safeParse(Operation.parse)
+    let safeParse = Utils.safeParse(. Operation.parse)
 
     Js_.readQuery(
       jsClient,
@@ -821,7 +821,7 @@ let make: (
       ~optimistic,
     )
     ->Js.toOption
-    ->Belt.Option.map(safeParse)
+    ->Belt.Option.mapU(safeParse)
   }
 
   let resetStore: unit => Js.Promise.t<
@@ -852,7 +852,7 @@ let make: (
     ~mapJsVariables=Utils.identity,
     variables,
   ) => {
-    let safeParse = Utils.safeParse(Operation.parse)
+    let safeParse = Utils.safeParse(. Operation.parse)
 
     let jsObservable = Js_.subscribe(
       jsClient,
@@ -881,9 +881,9 @@ let make: (
             }
           }
 
-        let onError' = onError->Belt.Option.map(onError => {
+        let onError' = onError->Belt.Option.mapU((. onError) => {
           let return = unknown =>
-            Obj.magic(unknown)->ApolloError.Js_.ensureApolloError->ApolloError.fromJs->onError
+            Obj.magic(unknown)->ApolloError.Js_.ensureApolloError->ApolloError.fromJs(. _)->onError
           return
         })
 
@@ -908,7 +908,7 @@ let make: (
     ~pollInterval=?,
     variables,
   ) => {
-    let safeParse = Utils.safeParse(Operation.parse)
+    let safeParse = Utils.safeParse(. Operation.parse)
 
     jsClient
     ->Js_.watchQuery(
@@ -999,7 +999,7 @@ let make: (
     ~update,
     variables,
   ) => {
-    let safeParse = Utils.safeParse(Operation.parse)
+    let safeParse = Utils.safeParse(. Operation.parse)
 
     jsClient
     ->Js_.updateQuery(
@@ -1025,7 +1025,7 @@ let make: (
         ->Js.Nullable.fromOption,
     )
     ->Js.toOption
-    ->Belt.Option.map(safeParse)
+    ->Belt.Option.mapU(safeParse)
   }
 
   let updateFragment = (
@@ -1040,7 +1040,7 @@ let make: (
     ~update,
     (),
   ) => {
-    let safeParse = Utils.safeParse(Fragment.parse)
+    let safeParse = Utils.safeParse(. Fragment.parse)
 
     jsClient
     ->Js_.updateFragment(
@@ -1062,7 +1062,7 @@ let make: (
         ->Js.Nullable.fromOption,
     )
     ->Js.toOption
-    ->Belt.Option.map(safeParse)
+    ->Belt.Option.mapU(safeParse)
   }
 
   preserveJsPropsAndContext(

--- a/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.res
+++ b/src/@apollo/client/core/ApolloClient__Core_ObservableQuery.res
@@ -115,7 +115,7 @@ module ObservableQuery = {
     ~safeParse,
   ) => {
     let parseWithOnErrorCall = (jsData, onError) =>
-      switch safeParse(jsData) {
+      switch safeParse(. jsData) {
       | Ok(data) => Some(data)
       | Error({error}) =>
         onError(error)

--- a/src/@apollo/client/core/ApolloClient__Core_Types.res
+++ b/src/@apollo/client/core/ApolloClient__Core_Types.res
@@ -136,7 +136,7 @@ module MutationQueryReducer = {
       queryVariables: Js.Json.t, // ACTUAL: Record<string, any>
     }
 
-    type t<'jsData> = (Js.Json.t, options<'jsData>) => Js.Json.t
+    type t<'jsData> = (. Js.Json.t, options<'jsData>) => Js.Json.t
   }
 
   type options<'data> = {
@@ -148,11 +148,11 @@ module MutationQueryReducer = {
   type t<'data> = (Js.Json.t, options<'data>) => Js.Json.t
 
   let toJs: (
-    t<'data>,
+    . t<'data>,
     ~safeParse: Types.safeParse<'data, 'jsData>,
     Js.Json.t,
     Js_.options<'jsData>,
-  ) => Js.Json.t = (t, ~safeParse, previousResult, jsOptions) =>
+  ) => Js.Json.t = (. t, ~safeParse, previousResult, jsOptions) =>
     t(
       previousResult,
       {
@@ -175,12 +175,14 @@ module MutationQueryReducersMap = {
 
   type t<'data> = Js.Dict.t<MutationQueryReducer.t<'data>>
 
-  let toJs: (t<'data>, ~safeParse: Types.safeParse<'data, 'jsData>) => Js_.t<'jsData> = (
+  let toJs: (. t<'data>, ~safeParse: Types.safeParse<'data, 'jsData>) => Js_.t<'jsData> = (.
     t,
     ~safeParse,
   ) =>
     Js.Dict.map(
-      (. mutationQueryReducer) => mutationQueryReducer->MutationQueryReducer.toJs(~safeParse),
+      (. mutationQueryReducer) =>
+        (. json, options) =>
+          MutationQueryReducer.toJs(. mutationQueryReducer, ~safeParse, json, options),
       t,
     )
 }

--- a/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.res
+++ b/src/@apollo/client/core/ApolloClient__Core_WatchQueryOptions.res
@@ -16,7 +16,7 @@ module ErrorPolicy = {
     | Ignore
     | All
 
-  let toJs = x =>
+  let toJs = (. x) =>
     switch x {
     | None => #none
     | Ignore => #ignore
@@ -37,7 +37,7 @@ module FetchPolicy = {
     | NoCache
     | Standby
 
-  let toJs = (x): Js_.t =>
+  let toJs = (. x): Js_.t =>
     switch x {
     | CacheFirst => #"cache-first"
     | CacheOnly => #"cache-only"
@@ -54,7 +54,7 @@ module FetchPolicy__noCacheExtracted = {
   }
   type t = NoCache
 
-  let toJs = x =>
+  let toJs = (. x) =>
     switch x {
     | NoCache => "no-cache"
     }
@@ -74,7 +74,7 @@ module WatchQueryFetchPolicy = {
     | NoCache
     | Standby
 
-  let toJs = (x): Js_.t =>
+  let toJs = (. x): Js_.t =>
     switch x {
     | CacheAndNetwork => #"cache-and-network"
     | CacheFirst => #"cache-first"
@@ -111,10 +111,10 @@ module QueryOptions = {
     ~mapJsVariables: 'jsVariables => 'jsVariables,
     ~serializeVariables: 'variables => 'jsVariables,
   ) => Js_.t<'jsVariables> = (t, ~mapJsVariables, ~serializeVariables) => {
-    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(FetchPolicy.toJs),
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.mapU(FetchPolicy.toJs),
     query: t.query,
     variables: t.variables->serializeVariables->mapJsVariables,
-    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    errorPolicy: ?t.errorPolicy->Belt.Option.mapU(ErrorPolicy.toJs),
     context: ?t.context,
   }
 }
@@ -149,11 +149,11 @@ module WatchQueryOptions = {
     ~mapJsVariables: 'jsVariables => 'jsVariables,
     ~serializeVariables: 'variables => 'jsVariables,
   ) => Js_.t<'jsVariables> = (t, ~mapJsVariables, ~serializeVariables) => {
-    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
-    nextFetchPolicy: ?t.nextFetchPolicy->Belt.Option.map(WatchQueryFetchPolicy.toJs),
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.mapU(WatchQueryFetchPolicy.toJs),
+    nextFetchPolicy: ?t.nextFetchPolicy->Belt.Option.mapU(WatchQueryFetchPolicy.toJs),
     query: t.query,
     variables: t.variables->serializeVariables->mapJsVariables,
-    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    errorPolicy: ?t.errorPolicy->Belt.Option.mapU(ErrorPolicy.toJs),
     context: ?t.context,
     pollInterval: ?t.pollInterval,
   }
@@ -172,7 +172,7 @@ module UpdateQueryFn = {
     //     variables?: TSubscriptionVariables;
     // }) => TData;
     type t<'jsQueryData, 'subscriptionVariables, 'jsSubscriptionData> = (
-      'jsQueryData,
+      . 'jsQueryData,
       t_options<'jsSubscriptionData, 'subscriptionVariables>,
     ) => 'jsQueryData
   }
@@ -198,24 +198,23 @@ module UpdateQueryFn = {
     ~querySafeParse,
     ~querySerialize,
     ~subscriptionSafeParse,
-    jsQueryData,
-    {subscriptionData: {data}},
   ) =>
-    switch (jsQueryData->querySafeParse, data->subscriptionSafeParse) {
-    | (Ok(queryData), Ok(subscriptionData)) =>
-      t(
-        queryData,
-        {
-          subscriptionData: {
-            data: subscriptionData,
+    (. jsQueryData, {subscriptionData: {data}}) =>
+      switch (querySafeParse(. jsQueryData), subscriptionSafeParse(. data)) {
+      | (Ok(queryData), Ok(subscriptionData)) =>
+        t(
+          queryData,
+          {
+            subscriptionData: {
+              data: subscriptionData,
+            },
           },
-        },
-      )->querySerialize
-    | (Error(parseError), _)
-    | (_, Error(parseError)) =>
-      onParseError(parseError)
-      jsQueryData
-    }
+        )->querySerialize
+      | (Error(parseError), _)
+      | (_, Error(parseError)) =>
+        onParseError(parseError)
+        jsQueryData
+      }
 }
 
 module SubscribeToMoreOptions = {
@@ -261,13 +260,14 @@ module SubscribeToMoreOptions = {
   ) => {
     document: t.document,
     variables: t.variables,
-    updateQuery: ?t.updateQuery->Belt.Option.map(
+    updateQuery: ?t.updateQuery->Belt.Option.mapU((. onUpdateQueryFn) =>
       UpdateQueryFn.toJs(
+        onUpdateQueryFn,
         ~onParseError=onUpdateQueryParseError,
         ~querySafeParse,
         ~querySerialize,
         ~subscriptionSafeParse,
-      ),
+      )
     ),
     onError: ?t.onError,
     context: ?t.context,
@@ -308,25 +308,25 @@ module SubscriptionOptions = {
   ) => Js_.t<'jsVariables> = (t, ~mapJsVariables, ~serializeVariables) => {
     query: t.query,
     variables: t.variables->serializeVariables->mapJsVariables,
-    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(FetchPolicy.toJs),
-    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.mapU(FetchPolicy.toJs),
+    errorPolicy: ?t.errorPolicy->Belt.Option.mapU(ErrorPolicy.toJs),
     context: ?t.context,
   }
 }
 
 module MutationUpdaterFn = {
   module Js_ = {
-    type t<'jsData> = (ApolloCache.t<Js.Json.t>, FetchResult.Js_.t<'jsData>) => unit // Non-Js_ cache is correct here
+    type t<'jsData> = (. ApolloCache.t<Js.Json.t>, FetchResult.Js_.t<'jsData>) => unit // Non-Js_ cache is correct here
   }
 
   type t<'data> = (ApolloCache.t<Js.Json.t>, FetchResult.t<'data>) => unit
 
-  let toJs: (t<'data>, ~safeParse: Types.safeParse<'data, 'jsData>) => Js_.t<'jsData> = (
+  let toJs: (. t<'data>, ~safeParse: Types.safeParse<'data, 'jsData>) => Js_.t<'jsData> = (.
     mutationUpdaterFn,
     ~safeParse,
-    cache,
-    jsFetchResult,
-  ) => mutationUpdaterFn(cache, jsFetchResult->FetchResult.fromJs(~safeParse))
+  ) =>
+    (. cache, jsFetchResult) =>
+      mutationUpdaterFn(cache, FetchResult.fromJs(jsFetchResult, ~safeParse))
 }
 
 module RefetchQueryDescription = {
@@ -351,12 +351,13 @@ module RefetchQueryDescription = {
 
   type t = array<t_variant>
 
-  let toJs: t => Js_.t = Belt.Array.map(_, x =>
-    switch x {
-    | PureQueryOptions(options) => Js_.Union.pureQueryOptions(options->PureQueryOptions.toJs)
-    | String(string) => Js_.Union.string(string)
-    }
-  )
+  let toJs: (. t) => Js_.t = (. arr) =>
+    Belt.Array.mapU(arr, (. x) =>
+      switch x {
+      | PureQueryOptions(options) => Js_.Union.pureQueryOptions(options->PureQueryOptions.toJs)
+      | String(string) => Js_.Union.string(string)
+      }
+    )
 }
 
 module MutationOptions = {
@@ -375,7 +376,7 @@ module MutationOptions = {
       // ...extends MutationBaseOption,
       awaitRefetchQueries?: bool,
       errorPolicy?: ErrorPolicy.Js_.t,
-      optimisticResponse?: 'jsVariables => 'jsData,
+      optimisticResponse?: (. 'jsVariables) => 'jsData,
       update?: MutationUpdaterFn.Js_.t<'jsData>,
       updateQueries?: MutationQueryReducersMap.Js_.t<'jsData>,
       refetchQueries?: RefetchQueryDescription.Js_.t,
@@ -413,15 +414,19 @@ module MutationOptions = {
   ) => {
     awaitRefetchQueries: ?t.awaitRefetchQueries,
     context: ?t.context,
-    errorPolicy: ?t.errorPolicy->Belt.Option.map(ErrorPolicy.toJs),
-    fetchPolicy: ?t.fetchPolicy->Belt.Option.map(FetchPolicy__noCacheExtracted.toJs),
+    errorPolicy: ?t.errorPolicy->Belt.Option.mapU(ErrorPolicy.toJs),
+    fetchPolicy: ?t.fetchPolicy->Belt.Option.mapU(FetchPolicy__noCacheExtracted.toJs),
     mutation: t.mutation,
-    optimisticResponse: ?t.optimisticResponse->Belt.Option.map((optimisticResponse, variables) =>
-      optimisticResponse(variables)->serialize
+    optimisticResponse: ?t.optimisticResponse->Belt.Option.mapU((. optimisticResponse) =>
+      (. variables) => optimisticResponse(variables)->serialize
     ),
-    refetchQueries: ?t.refetchQueries->Belt.Option.map(RefetchQueryDescription.toJs),
-    update: ?t.update->Belt.Option.map(MutationUpdaterFn.toJs(~safeParse)),
-    updateQueries: ?t.updateQueries->Belt.Option.map(MutationQueryReducersMap.toJs(~safeParse)),
+    refetchQueries: ?t.refetchQueries->Belt.Option.mapU(RefetchQueryDescription.toJs),
+    update: ?t.update->Belt.Option.mapU((. updater) =>
+      MutationUpdaterFn.toJs(. updater, ~safeParse)
+    ),
+    updateQueries: ?t.updateQueries->Belt.Option.mapU((. data) =>
+      MutationQueryReducersMap.toJs(. data, ~safeParse)
+    ),
     variables: t.variables->serializeVariables->mapJsVariables,
   }
 }

--- a/src/@apollo/client/errors/ApolloClient__Errors_ApolloError.res
+++ b/src/@apollo/client/errors/ApolloClient__Errors_ApolloError.res
@@ -133,14 +133,14 @@ type t = {
   stack: option<string>,
 }
 
-let fromJs: Js_.t => t = untrustedJs => {
+let fromJs: (. Js_.t) => t = (. untrustedJs) => {
   let js = Js_.ensureApolloError(untrustedJs)
   {
     extraInfo: js.extraInfo,
     graphQLErrors: js.graphQLErrors->Belt.Option.getWithDefault([]),
     networkError: js.networkError
     ->Js.toOption
-    ->Belt.Option.map(networkError =>
+    ->Belt.Option.mapU((. networkError) =>
       switch networkError->Js_.NetworkErrorUnion.classify {
       | Error(error) => FetchFailure(error)
       | ServerError(error) => BadStatus(error.statusCode, error)
@@ -165,7 +165,7 @@ let make: (
     networkError: Js.Nullable.undefined,
     errorMessage,
     extraInfo,
-  })->fromJs
+  })->fromJs(. _)
 
   {...errorWithoutNetworkError, networkError}
 }

--- a/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.res
+++ b/src/@apollo/client/link/core/ApolloClient__Link_Core_Types.res
@@ -169,7 +169,7 @@ module RequestHandler = {
   module Js_ = {
     // export declare type RequestHandler = (operation: Operation, forward: NextLink) => Observable<FetchResult> | null;
     type t = (
-      Operation.Js_.t,
+      . Operation.Js_.t,
       NextLink.Js_.t,
     ) => Js.Null.t<Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>>
   }
@@ -180,5 +180,5 @@ module RequestHandler = {
     NextLink.Js_.t,
   ) => option<Observable.t<FetchResult.Js_.t<Js.Json.t>, Js.Exn.t>>
 
-  let toJs: t => Js_.t = (t, operation, forward) => t(operation, forward)->Js.Null.fromOption
+  let toJs: t => Js_.t = t => (. operation, forward) => t(operation, forward)->Js.Null.fromOption
 }

--- a/src/@apollo/client/link/error/ApolloClient__Link_Error.res
+++ b/src/@apollo/client/link/error/ApolloClient__Link_Error.res
@@ -85,7 +85,7 @@ module ErrorResponse = {
 
   let fromJs: Js_.t => t = js => {
     graphQLErrors: js.graphQLErrors,
-    networkError: js.networkError->Belt.Option.map(networkError =>
+    networkError: js.networkError->Belt.Option.mapU((. networkError) =>
       switch networkError->Js_.NetworkErrorUnion.classify {
       | Error(error) => FetchFailure(error)
       | ServerError(error) => BadStatus(error.statusCode, error)

--- a/src/@apollo/client/link/retry/ApolloClient__Link_Retry_DelayFunction.res
+++ b/src/@apollo/client/link/retry/ApolloClient__Link_Retry_DelayFunction.res
@@ -5,13 +5,13 @@ module DelayFunction = {
     // export interface DelayFunction {
     //     (count: number, operation: Operation, error: any): number;
     // }
-    type t = (int, Operation.Js_.t, option<Js.Json.t>) => int
+    type t = (. int, Operation.Js_.t, option<Js.Json.t>) => int
   }
 
   type t = (~count: int, ~operation: Operation.t, ~error: option<Js.Json.t>) => int
 
-  let toJs: t => Js_.t = (t, count, operation, error) =>
-    t(~count, ~operation=operation->Operation.fromJs, ~error)
+  let toJs: (. t) => Js_.t = (. t) =>
+    (. count, operation, error) => t(~count, ~operation=operation->Operation.fromJs, ~error)
 }
 
 module DelayFunctionOptions = {

--- a/src/@apollo/client/link/retry/ApolloClient__Link_Retry_RetryFunction.res
+++ b/src/@apollo/client/link/retry/ApolloClient__Link_Retry_RetryFunction.res
@@ -5,13 +5,13 @@ module RetryFunction = {
     // export interface RetryFunction {
     //     (count: number, operation: Operation, error: any): boolean | Promise<boolean>;
     // }
-    type t = (int, Operation.Js_.t, option<Js.Json.t>) => Js.Promise.t<bool>
+    type t = (. int, Operation.Js_.t, option<Js.Json.t>) => Js.Promise.t<bool>
   }
 
   type t = (~count: int, ~operation: Operation.t, ~error: option<Js.Json.t>) => Js.Promise.t<bool>
 
-  let toJs: t => Js_.t = (t, count, operation, error) =>
-    t(~count, ~operation=operation->Operation.fromJs, ~error)
+  let toJs: (. t) => Js_.t = (. t) =>
+    (. count, operation, error) => t(~count, ~operation=operation->Operation.fromJs, ~error)
 }
 
 module RetryFunctionOptions = {

--- a/src/@apollo/client/link/retry/ApolloClient__Link_Retry_RetryLink.res
+++ b/src/@apollo/client/link/retry/ApolloClient__Link_Retry_RetryLink.res
@@ -9,23 +9,23 @@ module Options = {
     module T_delayUnion: {
       type t
       let delayFunctionOptions: DelayFunctionOptions.Js_.t => t
-      let delayFunction: DelayFunction.Js_.t => t
+      let delayFunction: (. DelayFunction.Js_.t) => t
     } = {
       @unboxed
       type rec t = Any('a): t
       let delayFunctionOptions = (v: DelayFunctionOptions.Js_.t) => Any(v)
-      let delayFunction = (v: DelayFunction.Js_.t) => Any(v)
+      let delayFunction = (. v: DelayFunction.Js_.t) => Any(v)
     }
 
     module T_attemptsUnion: {
       type t
       let retryFunctionOptions: RetryFunctionOptions.Js_.t => t
-      let retryFunction: RetryFunction.Js_.t => t
+      let retryFunction: (. RetryFunction.Js_.t) => t
     } = {
       @unboxed
       type rec t = Any('a): t
       let retryFunctionOptions = (v: RetryFunctionOptions.Js_.t) => Any(v)
-      let retryFunction = (v: RetryFunction.Js_.t) => Any(v)
+      let retryFunction = (. v: RetryFunction.Js_.t) => Any(v)
     }
 
     // export declare namespace RetryLink {
@@ -49,20 +49,20 @@ module Options = {
   }
 
   let toJs: t => Js_.t = t => {
-    delay: ?t.delay->Belt.Option.map(delay =>
+    delay: ?t.delay->Belt.Option.mapU((. delay) =>
       switch delay {
       | DelayFunctionOptions(delayFunctionOptions) =>
         Js_.T_delayUnion.delayFunctionOptions(delayFunctionOptions)
       | DelayFunction(delayFunction) =>
-        Js_.T_delayUnion.delayFunction(delayFunction->DelayFunction.toJs)
+        Js_.T_delayUnion.delayFunction(. DelayFunction.toJs(. delayFunction))
       }
     ),
-    attempts: ?t.attempts->Belt.Option.map(attempts =>
+    attempts: ?t.attempts->Belt.Option.mapU((. attempts) =>
       switch attempts {
       | RetryFunctionOptions(retryFunctionOptions) =>
         Js_.T_attemptsUnion.retryFunctionOptions(retryFunctionOptions->RetryFunctionOptions.toJs)
       | RetryFunction(retryFunction) =>
-        Js_.T_attemptsUnion.retryFunction(retryFunction->RetryFunction.toJs)
+        Js_.T_attemptsUnion.retryFunction(. RetryFunction.toJs(. retryFunction))
       }
     ),
   }

--- a/src/@apollo/client/link/ws/ApolloClient__Link_Ws.res
+++ b/src/@apollo/client/link/ws/ApolloClient__Link_Ws.res
@@ -50,7 +50,7 @@ module WebSocketLink = {
     Js_.make(
       #Configuration({
         uri,
-        options: options->Belt.Option.map(ClientOptions.toJs),
+        options: options->Belt.Option.mapU(ClientOptions.toJs),
         webSocketImpl,
       }),
     )

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseLazyQuery.res
@@ -16,7 +16,7 @@ module Js_ = {
   // export declare function useLazyQuery<TData = any, TVariables = OperationVariables>(query: DocumentNode, options?: LazyQueryHookOptions<TData, TVariables>): QueryTuple<TData, TVariables>;
   @module("@apollo/client")
   external useLazyQuery: (
-    Graphql.documentNode,
+    . Graphql.documentNode,
     LazyQueryHookOptions.Js_.t<'jsData, 'jsVariables>,
   ) => QueryTuple.Js_.t<'jsData, 'jsVariables> = "useLazyQuery"
 }
@@ -59,8 +59,8 @@ let useLazyQuery:
     ~ssr=?,
     (),
   ) => {
-    let safeParse = Utils.safeParse(Operation.parse)
-    let jsQueryTuple = Js_.useLazyQuery(
+    let safeParse = Utils.safeParse(. Operation.parse)
+    let jsQueryTuple = Js_.useLazyQuery(.
       Operation.query,
       LazyQueryHookOptions.toJs(
         {
@@ -133,9 +133,9 @@ let useLazyQueryWithVariables:
     ~ssr=?,
     variables,
   ) => {
-    let safeParse = Utils.safeParse(Operation.parse)
+    let safeParse = Utils.safeParse(. Operation.parse)
 
-    let jsQueryTuple = Js_.useLazyQuery(
+    let jsQueryTuple = Js_.useLazyQuery(.
       Operation.query,
       LazyQueryHookOptions.toJs(
         {

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseMutation.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseMutation.res
@@ -61,7 +61,7 @@ let useMutation:
     ~update=?,
     (),
   ) => {
-    let safeParse = Utils.safeParse(Operation.parse)
+    let safeParse = Utils.safeParse(. Operation.parse)
 
     let jsMutationTuple = Js_.useMutation(
       Operation.query,
@@ -139,7 +139,7 @@ let useMutationWithVariables:
     ~update=?,
     variables,
   ) => {
-    let safeParse = Utils.safeParse(Operation.parse)
+    let safeParse = Utils.safeParse(. Operation.parse)
 
     let jsMutationTuple = Js_.useMutation(
       Operation.query,

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseQuery.res
@@ -63,7 +63,7 @@ let useQuery:
     ~ssr=?,
     variables,
   ) => {
-    let safeParse = Utils.safeParse(Operation.parse)
+    let safeParse = Utils.safeParse(. Operation.parse)
 
     let jsQueryResult = Js_.useQuery(
       Operation.query,

--- a/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.res
+++ b/src/@apollo/client/react/hooks/ApolloClient__React_Hooks_UseSubscription.res
@@ -66,7 +66,7 @@ let useSubscription:
     ~skip=?,
     variables,
   ) => {
-    let safeParse = Utils.safeParse(Operation.parse)
+    let safeParse = Utils.safeParse(. Operation.parse)
 
     let jsSubscriptionResult = Js_.useSubscription(
       Operation.query,
@@ -90,7 +90,7 @@ let useSubscription:
       variables: jsSubscriptionResult.variables,
       loading: jsSubscriptionResult.loading,
       data: jsSubscriptionResult.data->Belt.Option.map(Operation.parse),
-      error: jsSubscriptionResult.error->Belt.Option.map(ApolloError.fromJs),
+      error: jsSubscriptionResult.error->Belt.Option.mapU(ApolloError.fromJs),
     }, jsSubscriptionResult)
   }
 

--- a/src/@apollo/client/utilities/policies/ApolloClient__Utilities_Policies_Pagination.res
+++ b/src/@apollo/client/utilities/policies/ApolloClient__Utilities_Policies_Pagination.res
@@ -17,25 +17,25 @@ module KeyArgs = ApolloClient__Cache_InMemory_Policies_FieldPolicy.FieldPolicy_K
 module Js_ = {
   // export declare function concatPagination<T = Reference>(keyArgs?: KeyArgs): FieldPolicy<T[]>;
   @module("@apollo/client/utilities") @val
-  external concatPagination: option<KeyArgs.Js_.t> => FieldPolicy.Js_.t<'existing> =
+  external concatPagination: (. option<KeyArgs.Js_.t>) => FieldPolicy.Js_.t<'existing> =
     "concatPagination"
 
   // export declare function offsetLimitPagination<T = Reference>(keyArgs?: KeyArgs): FieldPolicy<T[]>;
   @module("@apollo/client/utilities") @val
-  external offsetLimitPagination: option<KeyArgs.Js_.t> => FieldPolicy.Js_.t<'existing> =
+  external offsetLimitPagination: (. option<KeyArgs.Js_.t>) => FieldPolicy.Js_.t<'existing> =
     "offsetLimitPagination"
 
   // export declare function relayStylePagination<TNode = Reference>(keyArgs?: KeyArgs): FieldPolicy<TInternalRelay<TNode>>;
   @module("@apollo/client/utilities") @val
-  external relayStylePagination: option<KeyArgs.Js_.t> => FieldPolicy.Js_.t<'existing> =
+  external relayStylePagination: (. option<KeyArgs.Js_.t>) => FieldPolicy.Js_.t<'existing> =
     "relayStylePagination"
 }
 
 let concatPagination: KeyArgs.t => FieldPolicy.Js_.t<'existing> = keyArgs =>
-  Js_.concatPagination(Some(keyArgs->KeyArgs.toJs))
+  Js_.concatPagination(. Some(KeyArgs.toJs(. keyArgs)))
 
 let offsetLimitPagination: KeyArgs.t => FieldPolicy.Js_.t<'existing> = keyArgs =>
-  Js_.offsetLimitPagination(Some(keyArgs->KeyArgs.toJs))
+  Js_.offsetLimitPagination(. Some(KeyArgs.toJs(. keyArgs)))
 
 let relayStylePagination: KeyArgs.t => FieldPolicy.Js_.t<'existing> = keyArgs =>
-  Js_.relayStylePagination(Some(keyArgs->KeyArgs.toJs))
+  Js_.relayStylePagination(. Some(KeyArgs.toJs(. keyArgs)))

--- a/src/ApolloClient__Types.res
+++ b/src/ApolloClient__Types.res
@@ -41,4 +41,4 @@ type parseError = {
 
 type parseResult<'data> = result<'data, parseError>
 
-type safeParse<'data, 'jsData> = 'jsData => parseResult<'data>
+type safeParse<'data, 'jsData> = (. 'jsData) => parseResult<'data>

--- a/src/ApolloClient__Utils.res
+++ b/src/ApolloClient__Utils.res
@@ -8,11 +8,12 @@ let ensureError = ApolloError.ensureError
 
 external asJson: 'any => Js.Json.t = "%identity"
 
-let safeParse: ('jsData => 'data) => Types.safeParse<'data, 'jsData> = (parse, jsData) =>
-  switch parse(jsData) {
-  | data => Ok(data)
-  | exception Js.Exn.Error(error) => Error({value: jsData->asJson, error})
-  }
+let safeParse: (. 'jsData => 'data) => Types.safeParse<'data, 'jsData> = (. parse) =>
+  (. jsData) =>
+    switch parse(jsData) {
+    | data => Ok(data)
+    | exception Js.Exn.Error(error) => Error({value: jsData->asJson, error})
+    }
 
 let safeParseAndLiftToCommonResultProps: (
   ~jsData: option<'jsData>,
@@ -31,7 +32,7 @@ let safeParseAndLiftToCommonResultProps: (
   | (None, None) => None
   }
 
-  switch jsData->Belt.Option.map(jsData => safeParse(jsData)) {
+  switch Belt.Option.mapU(jsData, safeParse) {
   | Some(Error(parseError)) =>
     // Be careful we do not overwrite an existing error with a ParseError
     existingError->Belt.Option.isSome

--- a/src/subscriptions-transport-ws/ApolloClient__SubscriptionsTransportWs.res
+++ b/src/subscriptions-transport-ws/ApolloClient__SubscriptionsTransportWs.res
@@ -64,7 +64,7 @@ module ConnectionParamsOptions = {
     | Function(unit => ConnectionParams.t)
     | Promise(Js.Promise.t<ConnectionParams.t>)
 
-  let toJs: t => Js_.t = x =>
+  let toJs: (. t) => Js_.t = (. x) =>
     switch x {
     | ConnectionParams(v) => Js_.Union.connectionParams(v)
     | Function(v) => Js_.Union.fn(v)
@@ -106,8 +106,8 @@ module ClientOptions = {
     inactivityTimeout?: int,
   }
 
-  let toJs: t => Js_.t = t => {
-    connectionParams: ?t.connectionParams->Belt.Option.map(ConnectionParamsOptions.toJs),
+  let toJs: (. t) => Js_.t = (. t) => {
+    connectionParams: ?t.connectionParams->Belt.Option.mapU(ConnectionParamsOptions.toJs),
     timeout: ?t.timeout,
     reconnect: ?t.reconnect,
     reconnectionAttempts: ?t.reconnectionAttempts,
@@ -194,7 +194,7 @@ module SubscriptionClient = {
   ) => t = (~url, ~options=?, ~webSocketImpl=?, ~webSocketProtocols=?, ()) => {
     let jsSubscriptionClient = Js_.make(
       ~url,
-      ~options=?options->Belt.Option.map(ClientOptions.toJs),
+      ~options=?options->Belt.Option.mapU(ClientOptions.toJs),
       ~webSocketImpl?,
       ~webSocketProtocols?,
       (),


### PR DESCRIPTION
Changes the internal usage of most externals or function definitions used at runtime to be explicitly uncurried functions. The intent here is that the `Js_` modules are changed, not the public API. This will eliminate any ambiguous function calling conventions when the consumer of this library is on ReScript v10 or v11 on curried mode.
